### PR TITLE
fix: add hash-files config for CSS MIME type resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "assert_matches",
  "axum",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "blog-workspace"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "app",
  "chrono",
@@ -1768,7 +1768,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "app",
  "console_error_panic_hook",
@@ -3273,7 +3273,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markdown"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "katex",
  "leptos",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "app",
  "assert_matches",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "shared_utils"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "tokio-retry",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 members = ["app", "frontend", "markdown", "server", "shared_utils"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Alex Thola <alexthola@gmail.com>"]
 license = "AGPL-3.0-or-later"
 description = "A public webblog"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ end2end-dir = "end2end"
 #  The browserlist query used for optimizing the CSS.
 browserquery = "defaults"
 
+# Enable content hashing for static assets (JS, WASM, CSS) for cache busting.
+# This must match the LEPTOS_HASH_FILES=true flag used during Docker builds.
+hash-files = true
+
 # Set by cargo-leptos watch when building with that tool. Controls whether autoreload JS will be included in the head
 watch = false
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Blog API
-  version: 0.1.5
+  version: 0.1.6
 servers:
   - url: https://<your-domain>
 paths:


### PR DESCRIPTION
## Summary

- Adds `hash-files = true` to `[[workspace.metadata.leptos]]` in Cargo.toml
- Fixes CSS 404 / empty MIME type error on the deployed site

## Root cause

The Docker build uses `LEPTOS_HASH_FILES=true`, which produces hashed filenames like `blog.HASH.css`. At runtime, `resolve_css_href` reads `LeptosOptions.hash_files` to decide whether to look up the CSS hash. But `hash-files` was never set in the Cargo.toml metadata — it relied entirely on the `LEPTOS_HASH_FILES` env var override via the `config` crate. If that override didn't take effect, `hash_files` defaulted to `false`, causing the shell to emit `/pkg/blog.css` (unhashed) while the actual file was `blog.HASH.css` → 404 → empty MIME type.

## Test plan

- [ ] Verify `cargo test -p app --lib` passes (72/72 tests pass locally)
- [ ] Verify `cargo check -p server` compiles
- [ ] After deploy, confirm `/pkg/blog.HASH.css` loads with `Content-Type: text/css`
- [ ] Confirm site renders with full CSS styling