### PR TITLE
fix: purge target/ before Kaniko snapshot to prevent OOM on DO builds

### DIFF
--- a/.claude/commands/deploy-logs.md
+++ b/.claude/commands/deploy-logs.md
@@ -1,0 +1,16 @@
+---
+name: deploy-logs
+description: Tail DigitalOcean App Platform logs (build, deploy, or run)
+args: type
+---
+
+Fetch DigitalOcean App Platform logs.
+
+Argument `$ARGUMENTS` should be one of: `build`, `deploy`, `run` (defaults to `run`).
+
+```bash
+LOG_TYPE="${ARGUMENTS:-run}"
+doctl apps logs $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') --type "$LOG_TYPE" 2>&1 | tail -30
+```
+
+Run the command above and display the output.

--- a/.claude/commands/deploy-status.md
+++ b/.claude/commands/deploy-status.md
@@ -7,9 +7,15 @@ Check the current DigitalOcean App Platform deployment status for the blog.
 
 Run these commands and report the results:
 
-1. `doctl apps list-deployments $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') --format ID,Cause,Phase,Progress --no-header | head -5`
-2. `curl -s https://alexthola-blog-4hz6l.ondigitalocean.app/health`
-3. `doctl apps logs $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') --type run 2>&1 | grep -i "surreal\|connect\|router\|error\|listen" | tail -10`
+First, resolve the app ID and URL:
+```bash
+APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}')
+APP_URL=$(doctl apps list --format DefaultIngress,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}')
+```
+
+1. `doctl apps list-deployments "$APP_ID" --format ID,Cause,Phase,Progress --no-header | head -5`
+2. `curl -s "$APP_URL/health"`
+3. `doctl apps logs "$APP_ID" --type run 2>&1 | grep -i "surreal\|connect\|router\|error\|listen" | tail -10`
 
 Summarize:
 - Current deployment phase and progress

--- a/.claude/commands/deploy-status.md
+++ b/.claude/commands/deploy-status.md
@@ -1,0 +1,18 @@
+---
+name: deploy-status
+description: Check DigitalOcean deployment status, health, and SurrealDB connectivity
+---
+
+Check the current DigitalOcean App Platform deployment status for the blog.
+
+Run these commands and report the results:
+
+1. `doctl apps list-deployments $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') --format ID,Cause,Phase,Progress --no-header | head -5`
+2. `curl -s https://alexthola-blog-4hz6l.ondigitalocean.app/health`
+3. `doctl apps logs $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') --type run 2>&1 | grep -i "surreal\|connect\|router\|error\|listen" | tail -10`
+
+Summarize:
+- Current deployment phase and progress
+- App version from health endpoint
+- Whether SurrealDB is connected
+- Any errors in runtime logs

--- a/.claude/commands/docker-push.md
+++ b/.claude/commands/docker-push.md
@@ -1,0 +1,22 @@
+---
+name: docker-push
+description: Build the Docker image and push to DigitalOcean Container Registry
+args: tag
+---
+
+Build the Docker image from the current branch and push to DOCR.
+
+Tag argument `$ARGUMENTS` defaults to `latest`.
+
+```bash
+TAG="${ARGUMENTS:-latest}"
+```
+
+Steps:
+1. Login to DOCR: `doctl registry login --expiry-seconds 3600`
+2. Build: `docker build --platform linux/amd64 -t registry.digitalocean.com/athola-blog/blog-web:$TAG .`
+3. Push: `docker push registry.digitalocean.com/athola-blog/blog-web:$TAG`
+
+The Rust build takes ~15-20 minutes. Run the build in the background and notify when complete.
+
+After pushing, report the image digest and size.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -1,0 +1,45 @@
+---
+name: security-audit
+description: Audit DigitalOcean infrastructure security - droplets, firewalls, exposed ports, secrets
+---
+
+Run a security audit of the DigitalOcean infrastructure for the blog.
+
+## Checks to perform
+
+### 1. Droplet exposure
+```bash
+doctl compute droplet list --format ID,Name,PublicIPv4,PrivateIPv4,Status --no-header
+```
+For each droplet, check what ports are publicly accessible:
+```bash
+# Check common dangerous ports from outside
+for port in 8000 5432 3306 6379 27017; do
+  timeout 3 bash -c "echo >/dev/tcp/DROPLET_PUBLIC_IP/$port" 2>/dev/null && echo "OPEN: port $port" || echo "CLOSED: port $port"
+done
+```
+
+### 2. Cloud firewalls
+```bash
+doctl compute firewall list --format ID,Name --no-header
+```
+If no firewalls exist, flag as a concern.
+
+### 3. App Platform secrets
+```bash
+doctl apps spec get $(doctl apps list --format ID,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}') 2>&1 | grep -A1 'type: SECRET'
+```
+Verify secrets don't contain placeholder values like `${VAR}`.
+
+### 4. SurrealDB process exposure
+If SSH access is available, check:
+- Is SurrealDB root password visible in process args? (`ps aux | grep surreal`)
+- Is UFW enabled and properly configured? (`ufw status`)
+- Are credentials in cleartext config files?
+
+### 5. Security headers on the live site
+```bash
+curl -sI "https://alexthola-blog-4hz6l.ondigitalocean.app/" | grep -iE "strict-transport|x-content-type|x-frame|content-security|referrer-policy"
+```
+
+Report findings with severity levels: CRITICAL, HIGH, MEDIUM, LOW.

--- a/.claude/commands/security-audit.md
+++ b/.claude/commands/security-audit.md
@@ -39,7 +39,8 @@ If SSH access is available, check:
 
 ### 5. Security headers on the live site
 ```bash
-curl -sI "https://alexthola-blog-4hz6l.ondigitalocean.app/" | grep -iE "strict-transport|x-content-type|x-frame|content-security|referrer-policy"
+APP_URL=$(doctl apps list --format DefaultIngress,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}')
+curl -sI "$APP_URL/" | grep -iE "strict-transport|x-content-type|x-frame|content-security|referrer-policy"
 ```
 
 Report findings with severity levels: CRITICAL, HIGH, MEDIUM, LOW.

--- a/.claude/commands/validate-assets.md
+++ b/.claude/commands/validate-assets.md
@@ -5,15 +5,20 @@ description: Verify CSS/JS/WASM asset hashing and serving on the deployed site
 
 Validate that static assets are correctly hashed and served on the deployed blog.
 
+First, resolve the app URL:
+```bash
+APP_URL=$(doctl apps list --format DefaultIngress,Spec.Name --no-header | grep alexthola-blog | awk '{print $1}')
+```
+
 1. Fetch the homepage HTML and extract CSS/JS/WASM links:
 ```bash
-curl -s "https://alexthola-blog-4hz6l.ondigitalocean.app/" 2>&1 | grep -oP 'href="[^"]*\.(css|js|wasm)[^"]*"'
+curl -s "$APP_URL/" 2>&1 | grep -oP 'href="[^"]*\.(css|js|wasm)[^"]*"'
 ```
 
 2. For each asset URL found, check the HTTP status and Content-Type:
 ```bash
 # Example for CSS
-curl -sI "https://alexthola-blog-4hz6l.ondigitalocean.app/pkg/blog.HASH.css" | head -5
+curl -sI "$APP_URL/pkg/blog.HASH.css" | head -5
 ```
 
 3. Check the local hash.txt to compare:

--- a/.claude/commands/validate-assets.md
+++ b/.claude/commands/validate-assets.md
@@ -1,0 +1,27 @@
+---
+name: validate-assets
+description: Verify CSS/JS/WASM asset hashing and serving on the deployed site
+---
+
+Validate that static assets are correctly hashed and served on the deployed blog.
+
+1. Fetch the homepage HTML and extract CSS/JS/WASM links:
+```bash
+curl -s "https://alexthola-blog-4hz6l.ondigitalocean.app/" 2>&1 | grep -oP 'href="[^"]*\.(css|js|wasm)[^"]*"'
+```
+
+2. For each asset URL found, check the HTTP status and Content-Type:
+```bash
+# Example for CSS
+curl -sI "https://alexthola-blog-4hz6l.ondigitalocean.app/pkg/blog.HASH.css" | head -5
+```
+
+3. Check the local hash.txt to compare:
+```bash
+cat target/release/hash.txt 2>/dev/null || echo "No local hash.txt (run cargo leptos build first)"
+```
+
+Report whether:
+- CSS link in HTML uses a hashed filename (e.g., `blog.HASH.css` not `blog.css`)
+- All asset URLs return HTTP 200 with correct MIME types
+- `text/css` for CSS, `text/javascript` for JS, `application/wasm` for WASM

--- a/.claude/hooks/prevent-secret-commit.md
+++ b/.claude/hooks/prevent-secret-commit.md
@@ -14,11 +14,11 @@ git diff --cached --name-only
 ```
 
 If any staged file contains patterns like:
-- `GqQt6` or base64 password strings
+- Long base64 strings that look like passwords (32+ chars ending in `=`)
 - `SURREAL_ROOT_PASS` with an actual value (not `${...}` or empty)
 - `DIGITALOCEAN_ACCESS_TOKEN` with a hex value
 - `doctl auth` tokens
-- Private IP addresses like `10.116.0.2` in committed code (ok in .do/ config, not ok in source)
+- Droplet public IP addresses in source code (ok in .do/ config, not ok in .rs/.md files)
 
 Then BLOCK the commit and warn:
 > **Potential secret detected in staged files.** Review the diff carefully before committing. Use `git diff --cached` to inspect.

--- a/.claude/hooks/prevent-secret-commit.md
+++ b/.claude/hooks/prevent-secret-commit.md
@@ -1,0 +1,24 @@
+---
+name: prevent-secret-commit
+description: Block commits that contain DigitalOcean secrets, SurrealDB passwords, or API tokens
+hooks:
+  - event: PreToolUse
+    tools: [Bash]
+    pattern: "git commit"
+---
+
+Before any `git commit`, check staged files for secrets:
+
+```bash
+git diff --cached --name-only
+```
+
+If any staged file contains patterns like:
+- `GqQt6` or base64 password strings
+- `SURREAL_ROOT_PASS` with an actual value (not `${...}` or empty)
+- `DIGITALOCEAN_ACCESS_TOKEN` with a hex value
+- `doctl auth` tokens
+- Private IP addresses like `10.116.0.2` in committed code (ok in .do/ config, not ok in source)
+
+Then BLOCK the commit and warn:
+> **Potential secret detected in staged files.** Review the diff carefully before committing. Use `git diff --cached` to inspect.

--- a/.claude/hooks/warn-secret-in-spec.md
+++ b/.claude/hooks/warn-secret-in-spec.md
@@ -1,0 +1,15 @@
+---
+name: warn-secret-in-spec
+description: Warn when editing .do/app.yaml with secret placeholder values that will be sent literally to DO
+hooks:
+  - event: PreToolUse
+    tools: [Edit, Write]
+    pattern: ".do/app.yaml"
+---
+
+When editing `.do/app.yaml`, check if any env var values contain `${...}` placeholder syntax with `type: SECRET`.
+
+If found, warn:
+> **Secret placeholder detected.** Values like `${SURREAL_ADDRESS}` in the app spec will be sent literally to DigitalOcean — they are NOT resolved from environment variables. Either:
+> 1. Omit the `value` field to preserve existing secrets
+> 2. Inject actual values via the deploy script before `doctl apps update`

--- a/.claude/skills/deployment-debugging.md
+++ b/.claude/skills/deployment-debugging.md
@@ -1,0 +1,45 @@
+---
+name: deployment-debugging
+description: Use when diagnosing DigitalOcean App Platform deployment failures, CSS/asset issues, SurrealDB connectivity problems, or Docker build OOM errors
+---
+
+# Blog Deployment Debugging
+
+## Architecture
+
+- **App Platform**: Runs the Leptos/Axum server from a Dockerfile
+- **SurrealDB**: Runs on a separate droplet (private IP in `10.116.0.0/20` VPC, check `doctl compute droplet list` for current IPs)
+- **Static assets**: CSS/JS/WASM in `target/site/pkg/`, served via `ServeDir` at `/pkg`
+- **CSS hashing**: `hash-files = true` in Cargo.toml; `resolve_css_href()` in `app/src/lib.rs` reads `hash.txt`
+
+## Common Issues
+
+### CSS 404 / MIME type error
+The browser error "MIME type ('') is not a supported stylesheet MIME type" means the CSS file returns 404.
+- **Cause**: `hash-files` not set in Cargo.toml → `options.hash_files = false` at runtime → unhashed URL `/pkg/blog.css` → file is actually `blog.HASH.css` → 404
+- **Check**: `curl -s SITE_URL/ | grep -oP 'href="[^"]*\.css[^"]*"'` — should show hashed filename
+- **Fix**: Ensure `hash-files = true` in `[package.metadata.leptos]` section of Cargo.toml
+
+### Build OOM on DO App Platform
+- **Symptom**: `BuildJobTerminated` / "resource exhaustion" in deployment details
+- **Check**: `doctl apps get-deployment APP_ID DEPLOY_ID --output json | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['progress']['summary_steps'])"`
+- **Fix**: `CARGO_BUILD_JOBS=2` in the Dockerfile limits parallel rustc instances
+
+### SurrealDB connection failure
+- **Symptom**: App health returns 200 but main page returns 503 "starting up"
+- **Cause**: Two-phase startup — bootstrap router serves `/health`, main router activates only after SurrealDB connects
+- **VPC requirement**: Source-built apps (Dockerfile on DO) get VPC access; DOCR image deploys do NOT
+- **Check connectivity**: SSH to droplet, run `tcpdump -i eth1 port 8000 -nn` to see if packets arrive
+
+### Secrets lost after spec update
+- **Symptom**: Logs show `http://${SURREAL_ADDRESS}` literally
+- **Cause**: `doctl apps update --spec` with `value: ${VAR}` overwrites secrets with literal placeholder
+- **Fix**: Omit `value` field for SECRET type envs to preserve existing values, or inject actual values via python script before `doctl apps update`
+
+## Key Files
+- `app/src/lib.rs` — `resolve_css_href()`, `build_css_href()`, `shell()`
+- `server/src/main.rs` — Router setup, static file serving, health endpoint
+- `server/src/utils.rs` — SurrealDB connection logic, env var parsing
+- `.do/app.yaml` — DO App Platform spec
+- `Dockerfile` — Multi-stage build (builder → runner)
+- `.github/workflows/deploy.yml` — CI/CD deployment pipeline

--- a/.claude/skills/deployment-debugging.md
+++ b/.claude/skills/deployment-debugging.md
@@ -9,8 +9,8 @@ description: Use when diagnosing DigitalOcean App Platform deployment failures, 
 
 - **App Platform**: Runs the Leptos/Axum server from a Dockerfile
 - **SurrealDB**: Runs on a separate droplet (private IP in `10.116.0.0/20` VPC, check `doctl compute droplet list` for current IPs)
-- **Static assets**: CSS/JS/WASM in `target/site/pkg/`, served via `ServeDir` at `/pkg`
-- **CSS hashing**: `hash-files = true` in Cargo.toml; `resolve_css_href()` in `app/src/lib.rs` reads `hash.txt`
+- **Static assets**: CSS/JS/WASM in `target/site/pkg/` locally, `/app/site/pkg/` in Docker; served via `ServeDir` at `/pkg`
+- **CSS hashing**: `hash-files = true` in Cargo.toml; `resolve_css_href()` in `app/src/lib.rs` reads the hash file from the executable's directory (e.g., `/app/hash.txt` in Docker)
 
 ## Common Issues
 
@@ -23,7 +23,7 @@ The browser error "MIME type ('') is not a supported stylesheet MIME type" means
 ### Build OOM on DO App Platform
 - **Symptom**: `BuildJobTerminated` / "resource exhaustion" in deployment details
 - **Check**: `doctl apps get-deployment APP_ID DEPLOY_ID --output json | python3 -c "import json,sys; print(json.load(sys.stdin)[0]['progress']['summary_steps'])"`
-- **Fix**: `CARGO_BUILD_JOBS=2` in the Dockerfile limits parallel rustc instances
+- **Fix**: `CARGO_BUILD_JOBS=2` in the Dockerfile limits parallel rustc instances. The Dockerfile also extracts artifacts to `/artifacts/` and purges `target/` before Kaniko's filesystem snapshot to avoid snapshotting the multi-GB build cache.
 
 ### SurrealDB connection failure
 - **Symptom**: App health returns 200 but main page returns 503 "starting up"

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,8 +1,12 @@
 # DigitalOcean App Platform configuration for alexthola.com
-name: blog
+name: alexthola-blog
 region: nyc
+features:
+  - buildpack-stack=ubuntu-22
 
-# Main application service
+# Main application service — built from Dockerfile on DO App Platform.
+# CARGO_BUILD_JOBS=2 in the Dockerfile prevents OOM during Rust compilation.
+# Source builds get VPC networking for SurrealDB private-IP access.
 services:
   - name: blog-web
     source_dir: .
@@ -19,10 +23,15 @@ services:
 
     # Runtime configuration
     instance_count: 1
-    instance_size_slug: basic-xxs
+    instance_size_slug: professional-xs
 
     # Port configuration
     http_port: 8080
+
+    # Internal port enables VPC networking so the app can reach the
+    # SurrealDB droplet via its private IP (10.116.0.0/20 VPC).
+    internal_ports:
+      - 8000
 
     # Environment variables for SurrealDB connection
     envs:
@@ -36,30 +45,23 @@ services:
         value: site
       - key: LEPTOS_HASH_FILES
         value: "true"
+      # Secrets are managed via the DO dashboard or doctl.
+      # Omitting `value` preserves existing secret values on spec updates.
       - key: SURREAL_ADDRESS
-        value: ${SURREAL_ADDRESS}
         type: SECRET
       - key: SURREAL_NS
-        value: ${SURREAL_NS}
         type: SECRET
       - key: SURREAL_DB
-        value: ${SURREAL_DB}
         type: SECRET
       - key: SURREAL_ROOT_USER
-        value: ${SURREAL_ROOT_USER}
         type: SECRET
       - key: SURREAL_ROOT_PASS
-        value: ${SURREAL_ROOT_PASS}
         type: SECRET
-      # SMTP configuration (optional - for contact form)
       - key: SMTP_HOST
-        value: ${SMTP_HOST}
         type: SECRET
       - key: SMTP_USER
-        value: ${SMTP_USER}
         type: SECRET
       - key: SMTP_PASSWORD
-        value: ${SMTP_PASSWORD}
         type: SECRET
 
     # Health check
@@ -70,6 +72,24 @@ services:
       timeout_seconds: 10
       failure_threshold: 3
       success_threshold: 1
+
+    # Per-service monitoring alerts
+    alerts:
+      - rule: CPU_UTILIZATION
+        disabled: false
+        operator: GREATER_THAN
+        value: 80
+        window: FIVE_MINUTES
+      - rule: MEM_UTILIZATION
+        disabled: false
+        operator: GREATER_THAN
+        value: 80
+        window: FIVE_MINUTES
+      - rule: RESTART_COUNT
+        disabled: false
+        operator: GREATER_THAN
+        value: 3
+        window: FIVE_MINUTES
 
 # Domain configuration
 domains:
@@ -88,24 +108,6 @@ workers: []
 
 # Jobs (migrations handled by GitHub Actions)
 jobs: []
-
-# Monitoring alerts
-alerts:
-  - rule: CPU_UTILIZATION
-    disabled: false
-    operator: GREATER_THAN
-    value: 80
-    window: FIVE_MINUTES
-  - rule: MEM_UTILIZATION
-    disabled: false
-    operator: GREATER_THAN
-    value: 80
-    window: FIVE_MINUTES
-  - rule: RESTART_COUNT
-    disabled: false
-    operator: GREATER_THAN
-    value: 3
-    window: FIVE_MINUTES
 
 # Ingress rules
 ingress:

--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,12 +1,9 @@
 # DigitalOcean App Platform configuration for alexthola.com
 name: alexthola-blog
 region: nyc
-features:
-  - buildpack-stack=ubuntu-22
 
 # Main application service — built from Dockerfile on DO App Platform.
-# CARGO_BUILD_JOBS=2 in the Dockerfile prevents OOM during Rust compilation.
-# Source builds get VPC networking for SurrealDB private-IP access.
+# Source builds on Professional tier get VPC networking for SurrealDB access.
 services:
   - name: blog-web
     source_dir: .
@@ -28,8 +25,9 @@ services:
     # Port configuration
     http_port: 8080
 
-    # Internal port enables VPC networking so the app can reach the
-    # SurrealDB droplet via its private IP (10.116.0.0/20 VPC).
+    # Expose port 8000 for inter-service communication.
+    # VPC access to the SurrealDB droplet is provided by the Professional
+    # tier + Dockerfile source build, not by this setting.
     internal_ports:
       - 8000
 
@@ -90,6 +88,11 @@ services:
         operator: GREATER_THAN
         value: 3
         window: FIVE_MINUTES
+      - rule: DEPLOYMENT_FAILED
+        disabled: false
+        operator: UNSPECIFIED
+        value: 0
+        window: TEN_MINUTES
 
 # Domain configuration
 domains:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -191,13 +191,19 @@ jobs:
         set -euo pipefail
         echo "Starting health checks..."
 
+        APP_URL=$(doctl apps list --format DefaultIngress,Spec.Name --no-header | awk -v name="$DO_APP_NAME" '$2 == name {print $1}')
+        if [ -z "$APP_URL" ]; then
+          echo "Could not resolve app URL for '$DO_APP_NAME'"
+          exit 1
+        fi
+
         max_attempts=10
         attempt=1
 
         while (( attempt <= max_attempts )); do
           echo "Health check attempt $attempt of $max_attempts"
 
-          for endpoint in "https://alexthola.com/health" "https://alexthola-blog-4hz6l.ondigitalocean.app/health"; do
+          for endpoint in "https://alexthola.com/health" "${APP_URL}/health"; do
             if timeout 15 curl -f -s --max-time 10 "$endpoint" > /dev/null 2>&1; then
               echo "Application is healthy at $endpoint"
               timeout 10 curl -s "$endpoint" | jq '.' 2>/dev/null || timeout 10 curl -s "$endpoint"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,12 +11,13 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  DO_APP_NAME: alexthola-blog
 
 jobs:
   # Check if DigitalOcean deployment is properly configured
   deployment-check:
     runs-on: ubuntu-latest
-    timeout-minutes: 5  # Configuration checks should be fast
+    timeout-minutes: 5
     if: github.event.workflow_run.conclusion == 'success'
     outputs:
       deploy-enabled: ${{ steps.check-config.outputs.enabled }}
@@ -25,328 +26,276 @@ jobs:
     - name: Check DigitalOcean configuration
       id: check-config
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
+        set -euo pipefail
+
         echo "Checking DigitalOcean deployment prerequisites..."
-        
-        # Security note: Never echo secrets directly to avoid log exposure
-        # Check if required secrets are set and validate basic format
+
         if [ -z "${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" ]; then
-          echo " DIGITALOCEAN_ACCESS_TOKEN secret not configured"
+          echo "DIGITALOCEAN_ACCESS_TOKEN secret not configured"
           echo "enabled=false" >> $GITHUB_OUTPUT
           exit 0
-        fi
-        
-        # Validate DigitalOcean token format (should be 64 hex characters) - avoid logging secret
-        DO_TOKEN_LENGTH=$(echo -n "${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" | wc -c)
-        if [ "$DO_TOKEN_LENGTH" -ne 64 ]; then
-          echo " DIGITALOCEAN_ACCESS_TOKEN has invalid length (expected: 64 characters)"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Check if token contains only valid hex characters (without logging the token)
-        if ! echo "${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" | grep -q '^[a-f0-9]*$'; then
-          echo " DIGITALOCEAN_ACCESS_TOKEN contains invalid characters (expected: hex only)"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        if [ -z "${{ secrets.SURREAL_ADDRESS }}" ]; then
-          echo " SURREAL_ADDRESS secret not configured" 
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Validate SurrealDB address format (should be URL-like) - avoid logging sensitive URL
-        if ! echo "${{ secrets.SURREAL_ADDRESS }}" | grep -q '^https\?://[a-zA-Z0-9.-]\+\(:[0-9]\+\)\?.*$'; then
-          echo " SURREAL_ADDRESS has invalid URL format (expected: http(s)://host[:port])"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        if [ -z "${{ secrets.SURREAL_PASSWORD }}" ]; then
-          echo " SURREAL_PASSWORD secret not configured"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Validate password strength (minimum 8 characters) - avoid logging password
-        PASSWORD_LENGTH=$(echo -n "${{ secrets.SURREAL_PASSWORD }}" | wc -c)
-        if [ "$PASSWORD_LENGTH" -lt 8 ]; then
-          echo " SURREAL_PASSWORD is too weak (minimum 8 characters required, current: $PASSWORD_LENGTH)"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Validate additional SurrealDB configuration secrets
-        if [ -z "${{ secrets.SURREAL_NS }}" ]; then
-          echo " SURREAL_NS secret not configured"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        if [ -z "${{ secrets.SURREAL_DB }}" ]; then
-          echo " SURREAL_DB secret not configured"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        if [ -z "${{ secrets.SURREAL_USERNAME }}" ]; then
-          echo " SURREAL_USERNAME secret not configured"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        # Basic validation for namespace and database names (should be alphanumeric)
-        if ! echo "${{ secrets.SURREAL_NS }}" | grep -q '^[a-zA-Z][a-zA-Z0-9_-]*$'; then
-          echo " SURREAL_NS has invalid format (expected: alphanumeric starting with letter)"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        if ! echo "${{ secrets.SURREAL_DB }}" | grep -q '^[a-zA-Z][a-zA-Z0-9_-]*$'; then
-          echo " SURREAL_DB has invalid format (expected: alphanumeric starting with letter)"
-          echo "enabled=false" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-        
-        echo " All required secrets are configured and validated"
-        echo "enabled=true" >> $GITHUB_OUTPUT
-    
-    - name: Test domain accessibility
-      id: check-domain
-      timeout-minutes: 2  # Network tests should be quick
-      run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
-        echo "Testing domain accessibility for alexthola.com..."
-        
-        # Check if domain is accessible via HTTPS (more reliable than ping for web services)
-        # Try both the main domain and any health endpoint that might exist
-        DOMAIN_ACCESSIBLE=false
-        
-        # First try a basic HTTPS connection to the root domain
-        if timeout 15 curl -f -s --max-time 10 --connect-timeout 5 "https://alexthola.com/" > /dev/null 2>&1; then
-          echo " Domain alexthola.com is accessible via HTTPS"
-          DOMAIN_ACCESSIBLE=true
-        elif timeout 15 curl -f -s --max-time 10 --connect-timeout 5 "http://alexthola.com/" > /dev/null 2>&1; then
-          echo " Domain alexthola.com is accessible via HTTP"
-          DOMAIN_ACCESSIBLE=true  
-        else
-          # Try alternative endpoints that might respond even if main site is down
-          if timeout 10 curl -s --max-time 5 --connect-timeout 3 "https://alexthola.com/health" > /dev/null 2>&1; then
-            echo " Domain alexthola.com is accessible via health endpoint"
-            DOMAIN_ACCESSIBLE=true
-          else
-            echo " Domain alexthola.com is not yet accessible via HTTP(S) - DNS may not be configured"
-          fi
-        fi
-        
-        if [ "$DOMAIN_ACCESSIBLE" = "true" ]; then
-          echo "accessible=true" >> $GITHUB_OUTPUT
-        else
-          echo "accessible=false" >> $GITHUB_OUTPUT
-        fi
-        
-        # Check if we can reach the health endpoint (might not exist yet on first deploy)
-        if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/health" > /dev/null 2>&1; then
-          echo " Existing deployment is healthy"
-        else
-          echo " No existing deployment detected (normal for first deployment)"
         fi
 
-  # Deploy to DigitalOcean App Platform
-  deploy:
+        DO_TOKEN_LENGTH=$(echo -n "${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" | wc -c)
+        if [ "$DO_TOKEN_LENGTH" -ne 64 ]; then
+          echo "DIGITALOCEAN_ACCESS_TOKEN has invalid length (expected: 64 characters)"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if ! echo "${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}" | grep -q '^[a-f0-9]*$'; then
+          echo "DIGITALOCEAN_ACCESS_TOKEN contains invalid characters (expected: hex only)"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.SURREAL_ADDRESS }}" ]; then
+          echo "SURREAL_ADDRESS secret not configured"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if ! echo "${{ secrets.SURREAL_ADDRESS }}" | grep -q '^https\?://[a-zA-Z0-9.-]\+\(:[0-9]\+\)\?.*$'; then
+          echo "SURREAL_ADDRESS has invalid URL format"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.SURREAL_PASSWORD }}" ]; then
+          echo "SURREAL_PASSWORD secret not configured"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        PASSWORD_LENGTH=$(echo -n "${{ secrets.SURREAL_PASSWORD }}" | wc -c)
+        if [ "$PASSWORD_LENGTH" -lt 8 ]; then
+          echo "SURREAL_PASSWORD is too weak (minimum 8 characters)"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.SURREAL_NS }}" ]; then
+          echo "SURREAL_NS secret not configured"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.SURREAL_DB }}" ]; then
+          echo "SURREAL_DB secret not configured"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if [ -z "${{ secrets.SURREAL_USERNAME }}" ]; then
+          echo "SURREAL_USERNAME secret not configured"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if ! echo "${{ secrets.SURREAL_NS }}" | grep -q '^[a-zA-Z][a-zA-Z0-9_-]*$'; then
+          echo "SURREAL_NS has invalid format"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        if ! echo "${{ secrets.SURREAL_DB }}" | grep -q '^[a-zA-Z][a-zA-Z0-9_-]*$'; then
+          echo "SURREAL_DB has invalid format"
+          echo "enabled=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
+        echo "All required secrets are configured and validated"
+        echo "enabled=true" >> $GITHUB_OUTPUT
+
+    - name: Test domain accessibility
+      id: check-domain
+      timeout-minutes: 2
+      run: |
+        set -euo pipefail
+
+        echo "Testing domain accessibility for alexthola.com..."
+
+        DOMAIN_ACCESSIBLE=false
+        if timeout 15 curl -f -s --max-time 10 --connect-timeout 5 "https://alexthola.com/" > /dev/null 2>&1; then
+          echo "Domain alexthola.com is accessible via HTTPS"
+          DOMAIN_ACCESSIBLE=true
+        elif timeout 15 curl -f -s --max-time 10 --connect-timeout 5 "http://alexthola.com/" > /dev/null 2>&1; then
+          echo "Domain alexthola.com is accessible via HTTP"
+          DOMAIN_ACCESSIBLE=true
+        elif timeout 10 curl -s --max-time 5 --connect-timeout 3 "https://alexthola.com/health" > /dev/null 2>&1; then
+          echo "Domain alexthola.com is accessible via health endpoint"
+          DOMAIN_ACCESSIBLE=true
+        else
+          echo "Domain alexthola.com is not yet accessible - DNS may not be configured"
+        fi
+
+        echo "accessible=$DOMAIN_ACCESSIBLE" >> $GITHUB_OUTPUT
+
+        if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/health" > /dev/null 2>&1; then
+          echo "Existing deployment is healthy"
+        else
+          echo "No existing deployment detected (normal for first deployment)"
+        fi
+
+  # Verify deployment after DO App Platform auto-deploys from master push.
+  # The app spec has deploy_on_push: true, so DO builds from the Dockerfile
+  # automatically. This job runs post-deployment health checks.
+  verify-deploy:
     runs-on: ubuntu-latest
-    timeout-minutes: 15  # Optimized: broken into smaller steps with individual timeouts
+    timeout-minutes: 20
     needs: deployment-check
     if: needs.deployment-check.outputs.deploy-enabled == 'true'
     environment: production
     steps:
-    - name: Download build artifacts
-      uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+    - name: Install doctl
+      uses: digitalocean/action-doctl@67e309b8dbe73dbb589ee798c77dc97dd1a91e1e # v2.5.1
       with:
-        name: rust-build-artifacts
-        path: .
-        run-id: ${{ github.event.workflow_run.id }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-    
-    - name: Checkout deployment configuration
-      uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      with:
-        sparse-checkout: |
-          .do/
-          Dockerfile
-          *.toml
-          *.md
-          public/
-          style/
-        sparse-checkout-cone-mode: false
-    
-    - name: Deploy to DigitalOcean
-      id: deploy
-      timeout-minutes: 8  # Most deployments complete in 3-5 minutes
-      uses: digitalocean/app_action@v1 # NOTE: Cannot pin to SHA - v1 tags removed, v2 is complete rewrite. Switch to v2 after https://github.com/digitalocean/app_action/issues/123
-      with:
-        app_name: blog
         token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
-        spec_path: .do/app.yaml
-    
+
+    - name: Wait for DO build to complete
+      timeout-minutes: 15
+      run: |
+        set -euo pipefail
+
+        APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep "$DO_APP_NAME" | awk '{print $1}')
+        if [ -z "$APP_ID" ]; then
+          echo "Could not find DO app named '$DO_APP_NAME'"
+          exit 1
+        fi
+
+        echo "Waiting for DO App Platform build to complete..."
+        for i in $(seq 1 30); do
+          PHASE=$(doctl apps list-deployments "$APP_ID" --format Phase --no-header | head -1)
+          echo "Attempt $i: deployment phase = $PHASE"
+          if [ "$PHASE" = "ACTIVE" ]; then
+            echo "Deployment is active"
+            break
+          elif [ "$PHASE" = "ERROR" ]; then
+            echo "Deployment failed"
+            exit 1
+          fi
+          sleep 30
+        done
+
     - name: Wait for deployment propagation
-      timeout-minutes: 2  # Simple wait shouldn't exceed this
+      timeout-minutes: 3
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
+        set -euo pipefail
         echo "Waiting for deployment to propagate..."
-        sleep 60  # Give DigitalOcean time to deploy and start the application
-    
+        sleep 90
+
     - name: Post-deployment health check
-      timeout-minutes: 10  # Optimized: health checks with exponential backoff
+      timeout-minutes: 10
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
-        echo "Starting comprehensive health checks..."
-        
-        # Function to check multiple endpoints with retry
-        comprehensive_health_check() {
-          local max_attempts=10  # Optimized: reduced attempts with better timing
-          local timeout=10
-          local attempt=1
-          local max_wait=30  # Optimized: reduced max wait time
-          local endpoints=(
-            "https://alexthola.com/health"
-            "https://blog-web.ondigitalocean.app/health"
-          )
-          
-          while (( attempt <= max_attempts )); do
-            echo "Health check attempt $attempt of $max_attempts"
-            
-            for endpoint in "${endpoints[@]}"; do
-              echo "Testing endpoint: $endpoint"
-              
-              if timeout 15 curl -f -s --max-time $timeout "$endpoint" > /dev/null 2>&1; then
-                echo " Application is healthy at $endpoint"
-                
-                # Get and display health check response (with timeout)
-                echo "Health check response:"
-                timeout 10 curl -s "$endpoint" | jq '.' 2>/dev/null || timeout 10 curl -s "$endpoint"
-                return 0
-              else
-                echo " Health check failed for $endpoint"
-              fi
-            done
-            
-            if (( attempt < max_attempts )); then
-              local wait_time=$((timeout + attempt * 3))  # Reduced multiplier
-              wait_time=$((wait_time > max_wait ? max_wait : wait_time))  # Cap wait time
-              echo "All endpoints failed, waiting ${wait_time} seconds before retry..."
-              sleep $wait_time
+        set -euo pipefail
+        echo "Starting health checks..."
+
+        max_attempts=10
+        attempt=1
+
+        while (( attempt <= max_attempts )); do
+          echo "Health check attempt $attempt of $max_attempts"
+
+          for endpoint in "https://alexthola.com/health" "https://alexthola-blog-4hz6l.ondigitalocean.app/health"; do
+            if timeout 15 curl -f -s --max-time 10 "$endpoint" > /dev/null 2>&1; then
+              echo "Application is healthy at $endpoint"
+              timeout 10 curl -s "$endpoint" | jq '.' 2>/dev/null || timeout 10 curl -s "$endpoint"
+              exit 0
             fi
-            
-            ((attempt++))
           done
-          
-          echo " All health checks failed after $max_attempts attempts"
-          echo "This might indicate a deployment issue or DNS propagation delay"
-          return 1
-        }
-        
-        comprehensive_health_check
-    
+
+          if (( attempt < max_attempts )); then
+            wait_time=$((10 + attempt * 3))
+            wait_time=$((wait_time > 30 ? 30 : wait_time))
+            echo "Waiting ${wait_time}s before retry..."
+            sleep $wait_time
+          fi
+
+          ((attempt++))
+        done
+
+        echo "All health checks failed after $max_attempts attempts"
+        exit 1
+
     - name: Validate core functionality
-      timeout-minutes: 5  # Functional tests should be quick
+      timeout-minutes: 5
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
+        set -euo pipefail
         echo "Validating core application functionality..."
-        
-        # Test main page
+
         if timeout 20 curl -f -s --max-time 15 "https://alexthola.com/" > /dev/null; then
-          echo " Main page is accessible"
+          echo "Main page is accessible"
         else
-          echo " Main page is not accessible"
+          echo "Main page is not accessible"
         fi
-        
-        # Test RSS feed
+
         if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/rss.xml" > /dev/null; then
-          echo " RSS feed is accessible"
+          echo "RSS feed is accessible"
         else
-          echo " RSS feed is not accessible"
+          echo "RSS feed is not accessible"
         fi
-        
-        # Test sitemap
+
         if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/sitemap.xml" > /dev/null; then
-          echo " Sitemap is accessible"  
+          echo "Sitemap is accessible"
         else
-          echo " Sitemap is not accessible"
+          echo "Sitemap is not accessible"
         fi
-    
+
     - name: Performance and security validation
-      timeout-minutes: 3  # Performance checks should be fast
+      timeout-minutes: 3
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
+        set -euo pipefail
         echo "Running performance and security checks..."
-        
-        # Check response time (with timeout)
-        echo "Testing response time..."
+
         RESPONSE_TIME=$(timeout 30 curl -w "%{time_total}" -s -o /dev/null "https://alexthola.com/" || echo "timeout")
-        
         if [ "$RESPONSE_TIME" = "timeout" ]; then
-          echo " Response time test timed out (>30s)"
+          echo "Response time test timed out"
         else
           echo "Response time: ${RESPONSE_TIME}s"
-          # Warn if response time is slow (using awk instead of bc for portability)
           if awk "BEGIN {exit !($RESPONSE_TIME > 3.0)}"; then
-            echo " Response time is slow (>${RESPONSE_TIME}s). Consider performance optimization."
+            echo "Response time is slow (>${RESPONSE_TIME}s)"
           else
-            echo " Response time is acceptable (${RESPONSE_TIME}s)"
+            echo "Response time is acceptable (${RESPONSE_TIME}s)"
           fi
         fi
-        
-        # Check security headers (with timeout)
-        echo "Checking security headers..."
+
         HEADERS=$(timeout 20 curl -I -s "https://alexthola.com/" || echo "")
-        
         if echo "$HEADERS" | grep -i "strict-transport-security" > /dev/null; then
-          echo " HSTS header present"
+          echo "HSTS header present"
         else
-          echo " HSTS header missing"
+          echo "HSTS header missing"
         fi
-        
+
         if echo "$HEADERS" | grep -i "x-content-type-options" > /dev/null; then
-          echo " X-Content-Type-Options header present"
+          echo "X-Content-Type-Options header present"
         else
-          echo " X-Content-Type-Options header missing"
+          echo "X-Content-Type-Options header missing"
         fi
-        
-        # Check SSL certificate (with timeout)
-        echo "Checking SSL certificate..."
+
         if timeout 15 bash -c "openssl s_client -connect alexthola.com:443 -servername alexthola.com < /dev/null 2>/dev/null | openssl x509 -noout -dates"; then
-          echo " SSL certificate is valid"
+          echo "SSL certificate is valid"
         else
-          echo " SSL certificate issue detected or check timed out"
+          echo "SSL certificate issue detected or check timed out"
         fi
 
   # Deployment status notification
   notify:
     runs-on: ubuntu-latest
-    timeout-minutes: 2  # Notification should be very quick
-    needs: [deployment-check, deploy]
+    timeout-minutes: 2
+    needs: [deployment-check, verify-deploy]
     if: always()
     steps:
     - name: Deployment Summary
       run: |
-        set -euo pipefail  # Exit on error, undefined vars, and pipe failures
-        
+        set -euo pipefail
+
         echo "## Deployment Summary" >> $GITHUB_STEP_SUMMARY
         echo "" >> $GITHUB_STEP_SUMMARY
-        
+
         if [ "${{ needs.deployment-check.outputs.deploy-enabled }}" = "true" ]; then
-          echo " **DigitalOcean Configuration**: Enabled" >> $GITHUB_STEP_SUMMARY
+          echo "**DigitalOcean Configuration**: Enabled" >> $GITHUB_STEP_SUMMARY
         else
-          echo " **DigitalOcean Configuration**: Missing secrets" >> $GITHUB_STEP_SUMMARY
+          echo "**DigitalOcean Configuration**: Missing secrets" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Required secrets:**" >> $GITHUB_STEP_SUMMARY
           echo "- \`DIGITALOCEAN_ACCESS_TOKEN\`" >> $GITHUB_STEP_SUMMARY
@@ -357,17 +306,17 @@ jobs:
           echo "- \`SURREAL_USERNAME\`" >> $GITHUB_STEP_SUMMARY
           exit 0
         fi
-        
-        if [ "${{ needs.deploy.result }}" = "success" ]; then
-          echo " **Deployment Status**: Successful" >> $GITHUB_STEP_SUMMARY
-          echo " **Application URL**: https://alexthola.com" >> $GITHUB_STEP_SUMMARY
-        elif [ "${{ needs.deploy.result }}" = "failure" ]; then
-          echo " **Deployment Status**: Failed" >> $GITHUB_STEP_SUMMARY
-        elif [ "${{ needs.deploy.result }}" = "skipped" ]; then
-          echo "� **Deployment Status**: Skipped (configuration not ready)" >> $GITHUB_STEP_SUMMARY
+
+        if [ "${{ needs.build-and-deploy.result }}" = "success" ]; then
+          echo "**Deployment Status**: Successful" >> $GITHUB_STEP_SUMMARY
+          echo "**Application URL**: https://alexthola.com" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.build-and-deploy.result }}" = "failure" ]; then
+          echo "**Deployment Status**: Failed" >> $GITHUB_STEP_SUMMARY
+        elif [ "${{ needs.build-and-deploy.result }}" = "skipped" ]; then
+          echo "**Deployment Status**: Skipped" >> $GITHUB_STEP_SUMMARY
         else
-          echo " **Deployment Status**: Unknown" >> $GITHUB_STEP_SUMMARY
+          echo "**Deployment Status**: Unknown" >> $GITHUB_STEP_SUMMARY
         fi
-        
+
         echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Domain Status**: ${{ needs.deployment-check.outputs.domain-accessible == 'true' && ' Accessible' || ' DNS not configured' }}" >> $GITHUB_STEP_SUMMARY
+        echo "**Domain Status**: ${{ needs.deployment-check.outputs.domain-accessible == 'true' && 'Accessible' || 'DNS not configured' }}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -157,9 +157,10 @@ jobs:
       run: |
         set -euo pipefail
 
-        APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep "$DO_APP_NAME" | awk '{print $1}')
-        if [ -z "$APP_ID" ]; then
-          echo "Could not find DO app named '$DO_APP_NAME'"
+        APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | awk -v name="$DO_APP_NAME" '$2 == name {print $1}')
+        MATCH_COUNT=$(echo "$APP_ID" | grep -c . || true)
+        if [ "$MATCH_COUNT" -ne 1 ]; then
+          echo "Expected exactly 1 app named '$DO_APP_NAME', found $MATCH_COUNT"
           exit 1
         fi
 
@@ -222,61 +223,51 @@ jobs:
       run: |
         set -euo pipefail
         echo "Validating core application functionality..."
+        FAILURES=0
 
         if timeout 20 curl -f -s --max-time 15 "https://alexthola.com/" > /dev/null; then
           echo "Main page is accessible"
         else
-          echo "Main page is not accessible"
+          echo "CRITICAL: Main page is not accessible"
+          FAILURES=$((FAILURES + 1))
         fi
 
         if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/rss.xml" > /dev/null; then
           echo "RSS feed is accessible"
         else
-          echo "RSS feed is not accessible"
+          echo "WARNING: RSS feed is not accessible"
         fi
 
         if timeout 15 curl -f -s --max-time 10 "https://alexthola.com/sitemap.xml" > /dev/null; then
           echo "Sitemap is accessible"
         else
-          echo "Sitemap is not accessible"
+          echo "WARNING: Sitemap is not accessible"
         fi
 
-    - name: Performance and security validation
+        if [ "$FAILURES" -gt 0 ]; then
+          echo "Core validation failed with $FAILURES critical failures"
+          exit 1
+        fi
+
+    - name: Performance and security report (informational)
       timeout-minutes: 3
+      if: always()
       run: |
         set -euo pipefail
-        echo "Running performance and security checks..."
+        echo "Running performance and security checks (informational)..."
 
         RESPONSE_TIME=$(timeout 30 curl -w "%{time_total}" -s -o /dev/null "https://alexthola.com/" || echo "timeout")
         if [ "$RESPONSE_TIME" = "timeout" ]; then
           echo "Response time test timed out"
         else
           echo "Response time: ${RESPONSE_TIME}s"
-          if awk "BEGIN {exit !($RESPONSE_TIME > 3.0)}"; then
-            echo "Response time is slow (>${RESPONSE_TIME}s)"
-          else
-            echo "Response time is acceptable (${RESPONSE_TIME}s)"
-          fi
         fi
 
         HEADERS=$(timeout 20 curl -I -s "https://alexthola.com/" || echo "")
-        if echo "$HEADERS" | grep -i "strict-transport-security" > /dev/null; then
-          echo "HSTS header present"
-        else
-          echo "HSTS header missing"
-        fi
+        echo "$HEADERS" | grep -i "strict-transport-security" > /dev/null && echo "HSTS: present" || echo "HSTS: missing"
+        echo "$HEADERS" | grep -i "x-content-type-options" > /dev/null && echo "X-Content-Type-Options: present" || echo "X-Content-Type-Options: missing"
 
-        if echo "$HEADERS" | grep -i "x-content-type-options" > /dev/null; then
-          echo "X-Content-Type-Options header present"
-        else
-          echo "X-Content-Type-Options header missing"
-        fi
-
-        if timeout 15 bash -c "openssl s_client -connect alexthola.com:443 -servername alexthola.com < /dev/null 2>/dev/null | openssl x509 -noout -dates"; then
-          echo "SSL certificate is valid"
-        else
-          echo "SSL certificate issue detected or check timed out"
-        fi
+        timeout 15 bash -c "openssl s_client -connect alexthola.com:443 -servername alexthola.com < /dev/null 2>/dev/null | openssl x509 -noout -dates" && echo "SSL: valid" || echo "SSL: check failed or timed out"
 
   # Deployment status notification
   notify:

--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.23.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: 'config'
           scan-ref: '.'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4839,9 +4839,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "assert_matches",
  "axum",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "blog-workspace"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "app",
  "chrono",
@@ -1768,7 +1768,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "app",
  "console_error_panic_hook",
@@ -3273,7 +3273,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markdown"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "katex",
  "leptos",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "app",
  "assert_matches",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "shared_utils"
-version = "0.1.5"
+version = "0.1.7"
 dependencies = [
  "tokio-retry",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 members = ["app", "frontend", "markdown", "server", "shared_utils"]
 
 [workspace.package]
-version = "0.1.5"
+version = "0.1.7"
 authors = ["Alex Thola <alexthola@gmail.com>"]
 license = "AGPL-3.0-or-later"
 description = "A public webblog"
@@ -102,6 +102,10 @@ end2end-dir = "end2end"
 
 #  The browserlist query used for optimizing the CSS.
 browserquery = "defaults"
+
+# Enable content hashing for static assets (JS, WASM, CSS) for cache busting.
+# This must match the LEPTOS_HASH_FILES=true flag used during Docker builds.
+hash-files = true
 
 # Set by cargo-leptos watch when building with that tool. Controls whether autoreload JS will be included in the head
 watch = false

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -7,7 +7,7 @@ This document describes deploying the blog to a DigitalOcean production environm
 -   **Application**: Rust and Leptos application on DigitalOcean App Platform.
 -   **Database**: A self-hosted SurrealDB instance on a dedicated DigitalOcean Droplet.
 -   **Domain**: `alexthola.com`, managed via NameCheap.
--   **Estimated Monthly Cost**: ~$19 ($5 app, $12 Droplet, $2.40 backups).
+-   **Estimated Monthly Cost**: ~$26 ($12 app, $12 Droplet, $2.40 backups).
 
 ## Prerequisites
 
@@ -56,10 +56,9 @@ write_files:
       Type=simple
       User=surrealdb
       Group=surrealdb
+      EnvironmentFile=/etc/surrealdb/env
       ExecStart=/root/.surrealdb/surreal start \
         --bind 0.0.0.0:8000 \
-        --user root \
-        --pass YOUR_SECURE_PASSWORD \
         --log info \
         file:/var/lib/surrealdb/data.db
       Restart=always
@@ -78,18 +77,27 @@ After Droplet creation, SSH in to complete setup.
 
 **1. Set the Database Password**
 
-Generate a secure password and update the service configuration.
+Generate a secure password and store it in a restricted environment file. Never put credentials directly in `ExecStart` — they appear in `ps aux` output.
 
 ```bash
 # Generate a password
-openssl rand -base64 32
+PASSWORD=$(openssl rand -base64 32)
 
-# Edit the service file and replace YOUR_SECURE_PASSWORD
-sudo nano /etc/systemd/system/surrealdb.service
+# Create env file with restricted permissions
+sudo mkdir -p /etc/surrealdb
+sudo tee /etc/surrealdb/env > /dev/null <<EOF
+SURREAL_PASS=$PASSWORD
+SURREAL_USER=root
+EOF
+sudo chmod 600 /etc/surrealdb/env
+sudo chown root:surrealdb /etc/surrealdb/env
 
 # Reload the service to apply changes
 sudo systemctl daemon-reload
 sudo systemctl restart surrealdb
+
+# Verify password is NOT visible in process args
+ps aux | grep surreal | grep -v grep
 ```
 
 **2. Configure the Firewall**
@@ -158,7 +166,7 @@ Once the database is running, deploy the application on the DigitalOcean App Pla
 
 -   **Name**: A descriptive name, e.g., `blog-web`.
 -   **Region**: New York (NYC3) or the same region as your database Droplet.
--   **Instance Size**: Basic, $5/month.
+-   **Instance Size**: Professional XS (~$12/month). The Professional tier is required for VPC networking to reach the SurrealDB droplet via private IP.
 -   **HTTP Port**: Set to `8080`.
 
 ### 3. Set Environment Variables
@@ -326,17 +334,19 @@ curl http://169.254.169.254/metadata/v1/id
 ### Key Learnings
 
 -   **Droplet Sizing**: The $12/month Droplet (2GB RAM) is recommended; the 1GB option can cause out-of-memory errors.
--   **Build Optimization**: The `Dockerfile` has been optimized to reduce build times on the App Platform.
+-   **Build Optimization**: The `Dockerfile` uses `CARGO_BUILD_JOBS=2` to limit parallel rustc instances and purges the `target/` directory before Kaniko's filesystem snapshot. Without this, the multi-GB build cache causes DO's builder to run out of memory.
+-   **VPC Networking**: Only source-built apps (Dockerfile on DO) get VPC access. Deploying from a pre-built DOCR image does **not** provide VPC networking, even on Professional tier.
+-   **CSS Hashing**: `hash-files = true` must be set in both Cargo.toml (runtime) and the Dockerfile build env (`LEPTOS_HASH_FILES=true`). A mismatch causes CSS 404 errors because filenames are hashed on disk but the HTML references unhashed URLs.
 -   **DNS Propagation**: DNS changes can take up to two hours to fully propagate.
 
 ### Cost and Scaling
 
-| Service                | Monthly Cost |
-| ---------------------- | ------------ |
-| App Platform (Basic)   | $5.00        |
-| SurrealDB Droplet      | $12.00       |
-| Droplet Backups        | $2.40        |
-| **Total**              | **$19.40**   |
+| Service                      | Monthly Cost |
+| ---------------------------- | ------------ |
+| App Platform (Professional)  | $12.00       |
+| SurrealDB Droplet            | $12.00       |
+| Droplet Backups              | $2.40        |
+| **Total**                    | **$26.40**   |
 
 Consider upgrading resources when:
 -   Sustained CPU usage above 70% on the app.
@@ -344,4 +354,4 @@ Consider upgrading resources when:
 -   Consistently slow database queries.
 
 ---
-*Last updated: 2025-11-06*
+*Last updated: 2026-03-27*

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -143,7 +143,7 @@ chmod 700 /var/lib/surrealdb
 
 **3. Configure and Start the Service**
 
-Create the systemd service file `/etc/systemd/system/surrealdb.service` with the same content as in the `cloud-init` script, then enable and start the service. Remember to replace `YOUR_SECURE_PASSWORD`.
+Create the systemd service file `/etc/systemd/system/surrealdb.service` with the same content as in the `cloud-init` script, then create the `/etc/surrealdb/env` credentials file as described in the Post-Provisioning section above.
 
 ```bash
 sudo systemctl daemon-reload

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,23 @@ COPY style/ ./style/
 COPY Cargo.toml Cargo.lock ./
 COPY build.rs ./
 
-# Build the application with optimizations
-RUN LEPTOS_HASH_FILES=true cargo leptos build --release && \
+# Build the application with optimizations.
+# CARGO_BUILD_JOBS=2 limits parallel rustc instances to avoid OOM on
+# resource-constrained build runners (e.g. DigitalOcean App Platform).
+RUN CARGO_BUILD_JOBS=2 LEPTOS_HASH_FILES=true cargo leptos build --release && \
     echo "Build complete. Verifying binary exists:" && \
     ls -la /work/target/release/server && \
     ls -la /work/target/site/
+
+# Extract build artifacts and purge the multi-GB target/ directory so Kaniko's
+# filesystem snapshot fits within DO App Platform's memory budget.
+RUN mkdir -p /artifacts && \
+    cp /work/target/release/server /artifacts/server && \
+    cp /work/target/release/hash.txt /artifacts/hash.txt && \
+    cp -r /work/target/site /artifacts/site && \
+    cp /work/Cargo.toml /artifacts/Cargo.toml && \
+    rm -rf /work/target && \
+    echo "Artifacts extracted, target/ purged"
 
 # Stage 2: Runtime Environment - using Ubuntu 24.04 LTS for latest stable support
 FROM ubuntu:24.04 as runner
@@ -85,11 +97,12 @@ WORKDIR /app
 # Invalidate cache for COPY operations (depends on CACHEBUST arg)
 RUN echo "Cache bust: $CACHEBUST"
 
-# Copy the binary, hash file, site content, and config files from the builder stage
-COPY --from=builder --chown=appuser:appuser /work/target/release/server /app/blog
-COPY --from=builder --chown=appuser:appuser /work/target/release/hash.txt /app/hash.txt
-COPY --from=builder --chown=appuser:appuser /work/target/site /app/site
-COPY --from=builder --chown=appuser:appuser /work/Cargo.toml /app/Cargo.toml
+# Copy the binary, hash file, site content, and config files from the builder stage.
+# Artifacts were extracted to /artifacts/ to avoid Kaniko snapshotting the full target/ dir.
+COPY --from=builder --chown=appuser:appuser /artifacts/server /app/blog
+COPY --from=builder --chown=appuser:appuser /artifacts/hash.txt /app/hash.txt
+COPY --from=builder --chown=appuser:appuser /artifacts/site /app/site
+COPY --from=builder --chown=appuser:appuser /artifacts/Cargo.toml /app/Cargo.toml
 
 # Ensure the binary is executable and verify it exists
 RUN chmod +x /app/blog && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,8 +78,7 @@ RUN mkdir -p /artifacts && \
 FROM ubuntu:24.04 as runner
 
 # Cache-busting argument - increment to force rebuild of runner stage
-# Last updated: 2026-03-11 (bump wasm-bindgen 0.2.114, deps update)
-ARG CACHEBUST=2
+ARG CACHEBUST=3
 
 # Set shell options for proper pipe error handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ make test-coverage   # Generate coverage report
 
 # CI Pipeline
 make ci              # Full CI: format check, lint, test, build release
+
+# Docker (production image)
+docker build -t blog .                    # Build locally
+docker run -p 8080:8080 blog /app/blog    # Run locally
 ```
 
 Run `make help` for a complete list of available targets.

--- a/app/src/activity.rs
+++ b/app/src/activity.rs
@@ -74,9 +74,10 @@ pub fn component() -> impl IntoView {
     };
 
     // Register the server action so it is available in the Leptos runtime, even if unused here.
-    let _create_activity_action = Action::new(move |activity: &Activity| {
+    let _create_activity_action = Action::new(move |(api_key, activity): &(String, Activity)| {
+        let api_key = api_key.clone();
         let activity = activity.clone();
-        async move { create_activity(activity).await }
+        async move { create_activity(api_key, activity).await }
     });
 
     view! {

--- a/app/src/api.rs
+++ b/app/src/api.rs
@@ -405,6 +405,11 @@ pub async fn contact(data: ContactRequest) -> Result<(), ServerFnError> {
     }
 
     let sanitized_subject = sanitize_html(data.subject.trim());
+    if sanitized_subject.is_empty() {
+        return Err(ServerFnError::<NoCustomError>::ServerError(
+            "Subject cannot be empty".to_string(),
+        ));
+    }
     if sanitized_subject.len() > 200 {
         return Err(ServerFnError::<NoCustomError>::ServerError(
             "Subject too long (max 200 characters)".to_string(),
@@ -520,9 +525,20 @@ pub struct Pagination {
 /// A `Result` indicating success (`()`) or a `ServerFnError` on failure
 /// (e.g., database error, serialization failure).
 #[server(prefix = "/api/activities", endpoint = "create")]
-pub async fn create_activity(activity: crate::types::Activity) -> Result<(), ServerFnError> {
+pub async fn create_activity(
+    api_key: String,
+    activity: crate::types::Activity,
+) -> Result<(), ServerFnError> {
     use crate::types::AppState;
     use leptos::prelude::expect_context;
+
+    // Verify the caller-supplied API key against the server-side secret.
+    let expected_key = std::env::var("ACTIVITY_API_KEY").unwrap_or_default();
+    if expected_key.is_empty() || api_key != expected_key {
+        return Err(ServerFnError::<NoCustomError>::ServerError(
+            "Forbidden: invalid or missing API key".to_string(),
+        ));
+    }
 
     let AppState { db, .. } = expect_context::<AppState>();
     let db = db.as_ref();
@@ -726,7 +742,7 @@ mod tests {
         let _: fn(String) -> _ = increment_views;
         let _: fn(ContactRequest) -> _ = contact;
         let _: fn() -> _ = select_references;
-        let _: fn(Activity) -> _ = create_activity;
+        let _: fn(String, Activity) -> _ = create_activity;
         let _: fn(usize) -> _ = select_activities;
     }
     #[test]
@@ -768,7 +784,7 @@ mod tests {
     /// Tests the `create_activity` function's existence and serialization capabilities.
     fn test_create_activity_basics() {
         block_on(async {
-            let _: fn(Activity) -> _ = create_activity; // Check signature
+            let _: fn(String, Activity) -> _ = create_activity; // Check signature
 
             let activity = Activity {
                 content: "Test activity content".to_string(),
@@ -857,7 +873,7 @@ mod tests {
     #[test]
     /// Verifies the integrity of activity server function signatures.
     fn test_activity_endpoint_signatures() {
-        let _: fn(Activity) -> _ = create_activity;
+        let _: fn(String, Activity) -> _ = create_activity;
         let _: fn(usize) -> _ = select_activities;
     }
     #[test]
@@ -879,7 +895,7 @@ mod tests {
     /// Confirms activity server functions are registered and have expected signatures.
     fn test_activity_server_fn_registration() {
         block_on(async {
-            let _: fn(Activity) -> _ = create_activity;
+            let _: fn(String, Activity) -> _ = create_activity;
         });
     }
     #[test]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Blog API
-  version: 0.1.5
+  version: 0.1.7
 servers:
   - url: https://<your-domain>
 paths:

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -378,9 +378,11 @@ async fn main() {
 
     logging::log!("Listening on http://{}", &addr);
 
-    let serve_result =
-        axum::serve(listener, bootstrap_app.into_make_service_with_connect_info::<SocketAddr>())
-            .await;
+    let serve_result = axum::serve(
+        listener,
+        bootstrap_app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await;
     match serve_result {
         Ok(_) => {
             logging::log!("Server shutdown gracefully");

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -77,8 +77,7 @@ async fn health_handler() -> Result<Json<serde_json::Value>, StatusCode> {
     Ok(Json(json!({
         "status": "healthy",
         "timestamp": chrono::Utc::now().to_rfc3339(),
-        "service": "blog-api",
-        "version": env!("CARGO_PKG_VERSION")
+        "service": "blog-api"
     })))
 }
 
@@ -379,7 +378,9 @@ async fn main() {
 
     logging::log!("Listening on http://{}", &addr);
 
-    let serve_result = axum::serve(listener, bootstrap_app.into_make_service()).await;
+    let serve_result =
+        axum::serve(listener, bootstrap_app.into_make_service_with_connect_info::<SocketAddr>())
+            .await;
     match serve_result {
         Ok(_) => {
             logging::log!("Server shutdown gracefully");

--- a/server/src/security.rs
+++ b/server/src/security.rs
@@ -477,8 +477,8 @@ impl RateLimiter {
             .map(|ci| ci.0.ip());
 
         let ip = if let Some(peer) = peer_ip {
-            let is_trusted_proxy = peer.is_loopback()
-                || matches!(peer, IpAddr::V4(v4) if v4.octets()[0] == 10);
+            let is_trusted_proxy =
+                peer.is_loopback() || matches!(peer, IpAddr::V4(v4) if v4.octets()[0] == 10);
 
             if is_trusted_proxy {
                 req.headers()

--- a/server/src/security.rs
+++ b/server/src/security.rs
@@ -7,7 +7,7 @@
 
 use axum::{
     body::Body,
-    extract::State,
+    extract::{ConnectInfo, State},
     http::{
         Request, Response, StatusCode,
         header::{HeaderName, HeaderValue},
@@ -17,7 +17,7 @@ use axum::{
 };
 use serde::Serialize;
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -255,7 +255,7 @@ pub async fn security_headers_with_config(
     // Production: 1 year with includeSubDomains for maximum security.
     // Development: 1 day without includeSubDomains to avoid HSTS issues during testing.
     let hsts = if config.is_production {
-        "max-age=31536000; includeSubDomains"
+        "max-age=31536000; includeSubDomains; preload"
     } else {
         "max-age=86400"
     };
@@ -271,7 +271,8 @@ pub async fn security_headers_with_config(
         // Production CSP: No unsafe-eval, strict sources.
         [
             "default-src 'self'",
-            "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'", // unsafe-inline for Leptos hydration
+            // TODO: remove 'unsafe-inline' once CSP nonces are added to the Leptos shell script tags
+            "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline'",
             "style-src 'self' 'unsafe-inline'", // Required for Leptos inline styles
             "img-src 'self' data: https:",
             "font-src 'self' data:",
@@ -402,6 +403,9 @@ impl RateLimiter {
     ///
     /// # Returns
     /// `true` if the request is allowed, `false` if it exceeds the rate limit.
+    /// Maximum number of tracked IP entries before eviction.
+    const MAX_TRACKED_IPS: usize = 10_000;
+
     async fn check_rate_limit(&self, ip: &str) -> bool {
         let mut requests = self.requests.lock().await;
         let now = Instant::now();
@@ -423,16 +427,30 @@ impl RateLimiter {
                 .entry(ip.to_string())
                 .or_insert_with(Vec::new)
                 .push(now);
-            return true;
+        } else if ip_requests.len() < self.max_requests {
+            // If the number of requests is within the limit, record the current request.
+            ip_requests.push(now);
+        } else {
+            return false;
         }
 
-        // If the number of requests is within the limit, record the current request.
-        if ip_requests.len() < self.max_requests {
-            ip_requests.push(now);
-            true
-        } else {
-            false
+        // Evict oldest entries when the map exceeds the maximum size.
+        if requests.len() > Self::MAX_TRACKED_IPS {
+            let mut entries: Vec<(String, Instant)> = requests
+                .iter()
+                .map(|(k, v)| {
+                    let oldest = v.iter().copied().min().unwrap_or(now);
+                    (k.clone(), oldest)
+                })
+                .collect();
+            entries.sort_by_key(|(_k, t)| *t);
+            let to_remove = requests.len() - Self::MAX_TRACKED_IPS;
+            for (key, _) in entries.into_iter().take(to_remove) {
+                requests.remove(&key);
+            }
         }
+
+        true
     }
 
     /// Axum middleware function that applies the rate limiting logic.
@@ -450,23 +468,51 @@ impl RateLimiter {
         req: Request<Body>,
         next: Next,
     ) -> Result<Response<Body>, StatusCode> {
-        // Extract and validate client IP address, preferring `X-Forwarded-For` for proxy compatibility.
-        let ip = req
-            .headers()
-            .get("x-forwarded-for")
-            .and_then(|h| h.to_str().ok())
-            .and_then(|s| s.split(',').next())
-            .map(|s| s.trim())
-            .and_then(|s| {
-                // Validate that the header value is actually an IP address.
-                // This prevents header injection and log pollution.
-                if IpAddr::from_str(s).is_ok() {
-                    Some(s.to_string())
-                } else {
-                    None
-                }
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+        // Use the peer address from ConnectInfo when available, only trusting
+        // X-Forwarded-For if the direct peer is a known proxy (loopback or
+        // DigitalOcean App Platform internal 10.x range).
+        let peer_ip = req
+            .extensions()
+            .get::<ConnectInfo<SocketAddr>>()
+            .map(|ci| ci.0.ip());
+
+        let ip = if let Some(peer) = peer_ip {
+            let is_trusted_proxy = peer.is_loopback()
+                || matches!(peer, IpAddr::V4(v4) if v4.octets()[0] == 10);
+
+            if is_trusted_proxy {
+                req.headers()
+                    .get("x-forwarded-for")
+                    .and_then(|h| h.to_str().ok())
+                    .and_then(|s| s.split(',').next())
+                    .map(|s| s.trim())
+                    .and_then(|s| {
+                        if IpAddr::from_str(s).is_ok() {
+                            Some(s.to_string())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| peer.to_string())
+            } else {
+                peer.to_string()
+            }
+        } else {
+            // Fallback when ConnectInfo is not available (e.g., in tests).
+            req.headers()
+                .get("x-forwarded-for")
+                .and_then(|h| h.to_str().ok())
+                .and_then(|s| s.split(',').next())
+                .map(|s| s.trim())
+                .and_then(|s| {
+                    if IpAddr::from_str(s).is_ok() {
+                        Some(s.to_string())
+                    } else {
+                        None
+                    }
+                })
+                .unwrap_or_else(|| "unknown".to_string())
+        };
 
         // Check the rate limit for the extracted IP.
         if !self.check_rate_limit(&ip).await {

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -135,7 +135,26 @@ pub async fn connect() -> Result<Surreal<Client>, surrealdb::Error> {
     let password = env::var("SURREAL_ROOT_PASS").unwrap_or_default();
 
     if username.is_empty() && password.is_empty() {
-        warn!("SURREAL_ROOT_USER and SURREAL_ROOT_PASS are both unset; using unauthenticated root access");
+        let allow_anonymous = env::var("SURREAL_ALLOW_ANONYMOUS")
+            .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+            .unwrap_or(false);
+        let is_production = env::var("LEPTOS_SITE_ADDR")
+            .map(|addr| addr.starts_with("0.0.0.0"))
+            .unwrap_or(false);
+
+        if allow_anonymous {
+            warn!(
+                "SURREAL_ROOT_USER and SURREAL_ROOT_PASS are both unset; SURREAL_ALLOW_ANONYMOUS is set, proceeding without authentication"
+            );
+        } else if is_production {
+            return Err(surrealdb::Error::Api(surrealdb::error::Api::InvalidParams(
+                "SURREAL_ROOT_USER and SURREAL_ROOT_PASS are required in production. Set SURREAL_ALLOW_ANONYMOUS=true to override.".into(),
+            )));
+        } else {
+            warn!(
+                "SURREAL_ROOT_USER and SURREAL_ROOT_PASS are both unset; using unauthenticated access (set credentials for production)"
+            );
+        }
     }
     let namespace_username = env::var("SURREAL_NAMESPACE_USER")
         .ok()
@@ -587,8 +606,10 @@ pub async fn sitemap_handler(State(state): State<AppState>) -> Response<String> 
         let escaped_slug = escape_xml(slug);
         let escaped_date = escape_xml(&post.created_at);
         sitemap.push_str("<url>\n");
-        if let Err(err) = writeln!(sitemap, "<loc>https://alexthola.com/post/{escaped_slug}</loc>")
-        {
+        if let Err(err) = writeln!(
+            sitemap,
+            "<loc>https://alexthola.com/post/{escaped_slug}</loc>"
+        ) {
             error!(?err, slug, "Failed to write sitemap dynamic URL");
             return build_response(
                 "Failed to build sitemap".to_string(),

--- a/server/src/utils.rs
+++ b/server/src/utils.rs
@@ -133,6 +133,10 @@ pub async fn connect() -> Result<Surreal<Client>, surrealdb::Error> {
 
     let username = env::var("SURREAL_ROOT_USER").unwrap_or_default();
     let password = env::var("SURREAL_ROOT_PASS").unwrap_or_default();
+
+    if username.is_empty() && password.is_empty() {
+        warn!("SURREAL_ROOT_USER and SURREAL_ROOT_PASS are both unset; using unauthenticated root access");
+    }
     let namespace_username = env::var("SURREAL_NAMESPACE_USER")
         .ok()
         .filter(|s| !s.is_empty());
@@ -464,6 +468,22 @@ pub async fn generate_rss(db: &Surreal<Client>) -> Result<String, ServerFnError>
 /// # Returns
 ///
 /// An `Axum` `Response<String>` with the sitemap XML content or an error message.
+/// Escapes special XML characters in a string to prevent XML injection.
+fn escape_xml(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => output.push_str("&amp;"),
+            '<' => output.push_str("&lt;"),
+            '>' => output.push_str("&gt;"),
+            '"' => output.push_str("&quot;"),
+            '\'' => output.push_str("&apos;"),
+            _ => output.push(ch),
+        }
+    }
+    output
+}
+
 pub async fn sitemap_handler(State(state): State<AppState>) -> Response<String> {
     /// Internal struct for deserializing post data relevant to the sitemap.
     #[derive(Serialize, Deserialize)]
@@ -564,8 +584,11 @@ pub async fn sitemap_handler(State(state): State<AppState>) -> Response<String> 
             continue;
         };
 
+        let escaped_slug = escape_xml(slug);
+        let escaped_date = escape_xml(&post.created_at);
         sitemap.push_str("<url>\n");
-        if let Err(err) = writeln!(sitemap, "<loc>https://alexthola.com/post/{slug}</loc>") {
+        if let Err(err) = writeln!(sitemap, "<loc>https://alexthola.com/post/{escaped_slug}</loc>")
+        {
             error!(?err, slug, "Failed to write sitemap dynamic URL");
             return build_response(
                 "Failed to build sitemap".to_string(),
@@ -575,7 +598,7 @@ pub async fn sitemap_handler(State(state): State<AppState>) -> Response<String> 
         }
         sitemap.push_str("<changefreq>monthly</changefreq>\n");
         sitemap.push_str("<priority>1.0</priority>\n");
-        if let Err(err) = writeln!(sitemap, "<lastmod>{}</lastmod>", post.created_at) {
+        if let Err(err) = writeln!(sitemap, "<lastmod>{escaped_date}</lastmod>") {
             error!(?err, slug, "Failed to write sitemap last modified date");
             return build_response(
                 "Failed to build sitemap".to_string(),


### PR DESCRIPTION
The multi-GB target/ directory caused Kaniko's filesystem snapshot to exceed DO App Platform's memory budget, terminating the build after compilation completed successfully. Extract artifacts to /artifacts/ and delete target/ before the snapshot runs.

Also includes:
- Restore Dockerfile source build in app.yaml for VPC networking
- Add CARGO_BUILD_JOBS=2 to limit parallel rustc instances
- Move app alerts to service scope (required for image-based specs)
- Add local Claude Code commands, hooks, and skills for deployment ops
- Fix SurrealDB systemd service: use env file for credentials