### PR TITLE
deploy-hotfix-0.1.8: build fix, tunnel hardening, security rotation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,5 +8,6 @@ README.md
 .env*
 .github/
 scripts/
+!scripts/tunnel.sh
 .DS_Store
 Thumbs.db

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ COMMIT_EDITMSG
 
 # Doc review skill
 writing-clearly-and-concisely/
+
+# Claude Code session state (local scratch, may contain secrets)
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install cargo-leptos and wasm-bindgen-cli (pinned versions for reproducible builds)
-RUN cargo install cargo-leptos --version 0.3.2 && \
-    cargo install wasm-bindgen-cli --version 0.2.114 && \
+# --locked uses each crate's bundled Cargo.lock so yanked transitive deps (e.g. core2 0.4.0) don't break the install.
+RUN cargo install --locked cargo-leptos --version 0.3.2 && \
+    cargo install --locked wasm-bindgen-cli --version 0.2.114 && \
     rustup target add wasm32-unknown-unknown
 
 # Create app user for security

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p /artifacts && \
 FROM ubuntu:24.04 as runner
 
 # Cache-busting argument - increment to force rebuild of runner stage
-ARG CACHEBUST=3
+ARG CACHEBUST=4
 
 # Set shell options for proper pipe error handling
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -113,7 +113,8 @@ RUN chmod +x /app/blog && \
     file /app/blog
 
 # Copy tunnel wrapper script
-COPY --chmod=755 scripts/tunnel.sh /app/tunnel.sh
+COPY scripts/tunnel.sh /app/tunnel.sh
+RUN chmod 755 /app/tunnel.sh
 
 # Create secrets directory for SSH tunnel key (mounted by App Platform)
 RUN mkdir -p /app/secrets && chown appuser:appuser /app/secrets

--- a/Dockerfile
+++ b/Dockerfile
@@ -85,8 +85,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install runtime dependencies and create app user
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    autossh \
     ca-certificates \
+    curl \
     file \
+    openssh-client \
     && rm -rf /var/lib/apt/lists/* \
     && groupadd -r appuser && useradd -r -g appuser appuser
 
@@ -108,6 +111,12 @@ RUN chmod +x /app/blog && \
     echo "Verifying /app/blog exists in runner stage:" && \
     ls -la /app/blog && \
     file /app/blog
+
+# Copy tunnel wrapper script
+COPY --chmod=755 scripts/tunnel.sh /app/tunnel.sh
+
+# Create secrets directory for SSH tunnel key (mounted by App Platform)
+RUN mkdir -p /app/secrets && chown appuser:appuser /app/secrets
 
 # Create an empty .env to avoid noisy "No .env file found" logs in hosted deployments.
 RUN touch /app/.env && chown appuser:appuser /app/.env
@@ -132,5 +141,5 @@ ENV PORT="8080"
 # Expose port (DigitalOcean App Platform uses 8080)
 EXPOSE 8080
 
-# Run the application (absolute path for DigitalOcean compatibility)
-CMD ["/app/blog"]
+# Run the tunnel wrapper which starts SSH tunnel then the application
+CMD ["/app/tunnel.sh"]

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -49,25 +49,49 @@ mkdir -p ~/.ssh 2>/dev/null || true
 
 echo "Starting SSH tunnel: localhost:${LOCAL_PORT} -> ${TUNNEL_HOST}:${REMOTE_PORT}"
 
-# --- Preflight: synchronous ssh with verbose output so we can see WHY if it fails.
-# autossh -f would background before any verbose SSH output reaches stdout,
-# hiding the actual failure reason in DO logs.
+# --- Preflight: test the port-forward directly (no remote command exec).
+# This is compatible with keys restricted by `command="/usr/sbin/nologin"` +
+# `permitopen="localhost:${REMOTE_PORT}"` (i.e. port-forward-only keys),
+# which is the hardened posture we want. We open a short-lived forward on
+# a scratch local port and probe SurrealDB /health through it.
+PREFLIGHT_LOCAL=9001
+PREFLIGHT_LOG=/tmp/preflight-ssh.log
 echo "=== SSH PREFLIGHT BEGIN ==="
-ssh -vv -n -T \
+ssh -v -N -n \
     -i "$TUNNEL_KEY" \
     -p "$TUNNEL_PORT" \
+    -L "${PREFLIGHT_LOCAL}:localhost:${REMOTE_PORT}" \
     -o StrictHostKeyChecking=no \
     -o UserKnownHostsFile=/dev/null \
     -o BatchMode=yes \
     -o ConnectTimeout=10 \
-    "${TUNNEL_USER}@${TUNNEL_HOST}" \
-    "echo PREFLIGHT_OK; hostname; ss -ltn | grep ':${REMOTE_PORT} ' || echo 'no_listener_on_${REMOTE_PORT}'" 2>&1 \
-    | sed 's/^/[preflight] /'
-preflight_exit=${PIPESTATUS[0]}
-echo "=== SSH PREFLIGHT END (exit=${preflight_exit}) ==="
+    -o ExitOnForwardFailure=yes \
+    "${TUNNEL_USER}@${TUNNEL_HOST}" > "$PREFLIGHT_LOG" 2>&1 &
+preflight_pid=$!
 
-if [ "$preflight_exit" -ne 0 ]; then
-    echo "ERROR: SSH preflight failed. Starting app without tunnel (will retry connect to SurrealDB, expect HTTP 504)."
+preflight_ok=0
+for i in 1 2 3 4 5 6 7 8 9 10; do
+    sleep 1
+    if curl -sf --max-time 2 "http://localhost:${PREFLIGHT_LOCAL}/health" > /dev/null 2>&1; then
+        preflight_ok=1
+        echo "[preflight] port-forward to SurrealDB verified after ${i}s"
+        break
+    fi
+    if ! kill -0 "$preflight_pid" 2>/dev/null; then
+        echo "[preflight] ssh process exited early after ${i}s"
+        break
+    fi
+done
+
+# Tear down preflight ssh; the real tunnel runs via autossh below.
+kill "$preflight_pid" 2>/dev/null || true
+wait "$preflight_pid" 2>/dev/null || true
+
+sed 's/^/[preflight] /' "$PREFLIGHT_LOG" 2>/dev/null | tail -20
+echo "=== SSH PREFLIGHT END (ok=${preflight_ok}) ==="
+
+if [ "$preflight_ok" -ne 1 ]; then
+    echo "ERROR: SSH preflight port-forward failed. Starting app without tunnel (expect HTTP 504 until next deploy)."
     exec /app/blog
 fi
 

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -19,17 +19,30 @@ if [ -z "$TUNNEL_HOST" ]; then
 fi
 
 # Write SSH key from environment to file
-if [ -n "${TUNNEL_KEY_SECRET:-}" ]; then
+# Supports both base64-encoded (TUNNEL_KEY_B64) and raw (TUNNEL_KEY_SECRET) formats.
+# DO App Platform may strip newlines from env vars, so base64 is preferred.
+if [ -n "${TUNNEL_KEY_B64:-}" ]; then
     mkdir -p /app/secrets
-    # Use printf to avoid shell interpretation of key content
+    echo "$TUNNEL_KEY_B64" | base64 -d > "$TUNNEL_KEY"
+    chmod 600 "$TUNNEL_KEY"
+    unset TUNNEL_KEY_B64
+    echo "SSH key decoded from base64 to $TUNNEL_KEY"
+elif [ -n "${TUNNEL_KEY_SECRET:-}" ]; then
+    mkdir -p /app/secrets
+    # Use printf to write key content; trailing newline added explicitly
     printf '%s\n' "$TUNNEL_KEY_SECRET" > "$TUNNEL_KEY"
     chmod 600 "$TUNNEL_KEY"
     unset TUNNEL_KEY_SECRET
     echo "SSH key written to $TUNNEL_KEY"
 else
-    echo "ERROR: TUNNEL_KEY_SECRET not set"
+    echo "ERROR: No TUNNEL_KEY_B64 or TUNNEL_KEY_SECRET set"
     exec /app/blog
 fi
+
+# Debug: verify key is valid
+key_lines=$(wc -l < "$TUNNEL_KEY")
+echo "Key file has $key_lines lines"
+head -1 "$TUNNEL_KEY"
 
 # Create SSH directory for appuser
 mkdir -p ~/.ssh 2>/dev/null || true
@@ -40,6 +53,7 @@ echo "Starting SSH tunnel: localhost:${LOCAL_PORT} -> ${TUNNEL_HOST}:${REMOTE_PO
 # AUTOSSH_GATETIME=0: don't wait before first connection (required for non-interactive)
 export AUTOSSH_GATETIME=0
 autossh -f -N \
+    -v \
     -i "$TUNNEL_KEY" \
     -L "${LOCAL_PORT}:localhost:${REMOTE_PORT}" \
     -p "$TUNNEL_PORT" \

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -49,8 +49,29 @@ mkdir -p ~/.ssh 2>/dev/null || true
 
 echo "Starting SSH tunnel: localhost:${LOCAL_PORT} -> ${TUNNEL_HOST}:${REMOTE_PORT}"
 
-# Start autossh with persistent SSH tunnel
-# AUTOSSH_GATETIME=0: don't wait before first connection (required for non-interactive)
+# --- Preflight: synchronous ssh with verbose output so we can see WHY if it fails.
+# autossh -f would background before any verbose SSH output reaches stdout,
+# hiding the actual failure reason in DO logs.
+echo "=== SSH PREFLIGHT BEGIN ==="
+ssh -vv -n -T \
+    -i "$TUNNEL_KEY" \
+    -p "$TUNNEL_PORT" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o BatchMode=yes \
+    -o ConnectTimeout=10 \
+    "${TUNNEL_USER}@${TUNNEL_HOST}" \
+    "echo PREFLIGHT_OK; hostname; ss -ltn | grep ':${REMOTE_PORT} ' || echo 'no_listener_on_${REMOTE_PORT}'" 2>&1 \
+    | sed 's/^/[preflight] /'
+preflight_exit=${PIPESTATUS[0]}
+echo "=== SSH PREFLIGHT END (exit=${preflight_exit}) ==="
+
+if [ "$preflight_exit" -ne 0 ]; then
+    echo "ERROR: SSH preflight failed. Starting app without tunnel (will retry connect to SurrealDB, expect HTTP 504)."
+    exec /app/blog
+fi
+
+# Preflight succeeded -> real tunnel via autossh.
 export AUTOSSH_GATETIME=0
 autossh -f -N \
     -v \

--- a/scripts/tunnel.sh
+++ b/scripts/tunnel.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# SSH tunnel wrapper for SurrealDB connectivity.
+# Establishes a persistent tunnel to the SurrealDB droplet via autossh,
+# then starts the blog application with SURREAL_ADDRESS pointing to the tunnel.
+
+TUNNEL_HOST="${TUNNEL_HOST:-}"
+TUNNEL_PORT="${TUNNEL_PORT:-22}"
+TUNNEL_USER="${TUNNEL_USER:-root}"
+TUNNEL_KEY="/app/secrets/tunnel_key"
+REMOTE_PORT="${REMOTE_PORT:-8000}"
+LOCAL_PORT="${LOCAL_PORT:-9000}"
+
+echo "=== Blog Tunnel Wrapper ==="
+
+# If no tunnel host configured, skip tunnel and run app directly
+if [ -z "$TUNNEL_HOST" ]; then
+    echo "No TUNNEL_HOST set, starting app without tunnel"
+    exec /app/blog
+fi
+
+# Write SSH key from environment to file
+if [ -n "${TUNNEL_KEY_SECRET:-}" ]; then
+    mkdir -p /app/secrets
+    # Use printf to avoid shell interpretation of key content
+    printf '%s\n' "$TUNNEL_KEY_SECRET" > "$TUNNEL_KEY"
+    chmod 600 "$TUNNEL_KEY"
+    unset TUNNEL_KEY_SECRET
+    echo "SSH key written to $TUNNEL_KEY"
+else
+    echo "ERROR: TUNNEL_KEY_SECRET not set"
+    exec /app/blog
+fi
+
+# Create SSH directory for appuser
+mkdir -p ~/.ssh 2>/dev/null || true
+
+echo "Starting SSH tunnel: localhost:${LOCAL_PORT} -> ${TUNNEL_HOST}:${REMOTE_PORT}"
+
+# Start autossh with persistent SSH tunnel
+# AUTOSSH_GATETIME=0: don't wait before first connection (required for non-interactive)
+export AUTOSSH_GATETIME=0
+autossh -f -N \
+    -i "$TUNNEL_KEY" \
+    -L "${LOCAL_PORT}:localhost:${REMOTE_PORT}" \
+    -p "$TUNNEL_PORT" \
+    -o StrictHostKeyChecking=no \
+    -o UserKnownHostsFile=/dev/null \
+    -o ServerAliveInterval=15 \
+    -o ServerAliveCountMax=3 \
+    -o ExitOnForwardFailure=yes \
+    -o ConnectTimeout=10 \
+    "${TUNNEL_USER}@${TUNNEL_HOST}" 2>&1
+
+autossh_exit=$?
+if [ $autossh_exit -ne 0 ]; then
+    echo "WARNING: autossh exited with code $autossh_exit, starting app without tunnel"
+    exec /app/blog
+fi
+
+echo "autossh started, waiting for tunnel..."
+
+# Wait for tunnel to become healthy
+MAX_HEALTH_WAIT=30
+elapsed=0
+while [ $elapsed -lt $MAX_HEALTH_WAIT ]; do
+    if curl -sf "http://localhost:${LOCAL_PORT}/health" > /dev/null 2>&1; then
+        echo "Tunnel healthy after ${elapsed}s"
+        break
+    fi
+    sleep 2
+    elapsed=$((elapsed + 2))
+done
+
+if [ $elapsed -ge $MAX_HEALTH_WAIT ]; then
+    echo "WARNING: Tunnel not healthy after ${MAX_HEALTH_WAIT}s"
+fi
+
+# Override SURREAL_ADDRESS for the app to use the tunnel
+export SURREAL_ADDRESS="http://localhost:${LOCAL_PORT}"
+echo "Starting app with SURREAL_ADDRESS=${SURREAL_ADDRESS}"
+
+exec /app/blog


### PR DESCRIPTION
## Summary

Hotfix branch that unblocked the DO App Platform deploy and materially tightened the security posture of the SurrealDB tunnel. Commits span build/connectivity fixes through active security hardening.

## Major changes on this branch

**Build / connectivity**
- `fix(build): use --locked for cargo install` — yanked `core2 0.4.0` broke `cargo install cargo-leptos`; `--locked` uses the published crate's lockfile (commit 09946cd)
- DO App Platform blocks outbound :22 — moved sshd to also listen on :443 via systemd socket drop-in; `TUNNEL_PORT=443` in spec
- `fix(tunnel): improve SSH tunnel with base64 key support and debug logging` (commit b2250f5)
- `fix(tunnel): add synchronous SSH preflight with verbose output` (commit 1c1cfdf)
- `security(tunnel): preflight via port-forward instead of remote exec` (commit 51f0ab7)

**Security hardening (applied to droplet/spec, not in this diff)**
- Tunnel key restricted to `restrict,port-forwarding,command="/usr/sbin/nologin",permitopen="localhost:8000"` — key leak no longer yields root RCE, only a single TCP forward to SurrealDB
- Plaintext `TUNNEL_KEY_SECRET` removed from DO spec; only encrypted `TUNNEL_KEY_B64` retained
- Tunnel keypair rotated; old key revoked on droplet
- UFW: removed `22/tcp ALLOW IN Anywhere`; SSH:22 now home-IP + VPC only
- `unattended-upgrades` enabled for security pocket
- SurrealDB 2.4.0 → 2.6.5 on droplet (matches client SDK version)

## Test plan
- [x] Deploy builds and reaches ACTIVE on DO App Platform
- [x] `curl https://alexthola-blog-4hz6l.ondigitalocean.app/` returns HTTP 200
- [x] CSS, WASM, RSS assets return HTTP 200
- [x] SurrealDB connection logs show "Successfully connected to SurrealDB with retries"
- [x] sshd logs confirm restricted options active: `key options: command permitopen port-forwarding`
- [x] Old tunnel key denied (`Permission denied (publickey)`)
- [x] New tunnel key verified via port-forward (probe returns HTTP 200)

## Follow-ups (deferred)
- Caddy TLS reverse proxy (`db.alexthola.com` → `localhost:8000`) to retire the SSH tunnel
- DO Dedicated Egress IP for App Platform
- SurrealDB 3.x migration (requires Rust SDK bump and query audit)
- `jsonwebtoken` CVE-2026-25537 patch (requires `surrealdb` SDK 3.x)