### PR TITLE
docs(deployment): reflect Caddy reverse proxy architecture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,7 +143,7 @@ checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "assert_matches",
  "axum",
@@ -674,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "blog-workspace"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "app",
  "chrono",
@@ -1768,7 +1768,7 @@ checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "frontend"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "app",
  "console_error_panic_hook",
@@ -3273,7 +3273,7 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markdown"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "katex",
  "leptos",
@@ -5115,7 +5115,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "app",
  "assert_matches",
@@ -5242,7 +5242,7 @@ dependencies = [
 
 [[package]]
 name = "shared_utils"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "tokio-retry",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ resolver = "2"
 members = ["app", "frontend", "markdown", "server", "shared_utils"]
 
 [workspace.package]
-version = "0.1.7"
+version = "0.1.8"
 authors = ["Alex Thola <alexthola@gmail.com>"]
 license = "AGPL-3.0-or-later"
 description = "A public webblog"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -102,24 +102,72 @@ ps aux | grep surreal | grep -v grep
 
 **2. Configure the Firewall**
 
-To secure the database, restrict access to the App Platform's private VPC network.
-
-First, get your app's VPC IP range from the DigitalOcean dashboard under **Your App -> Settings -> VPC Network**.
-
-Then, configure the firewall on the Droplet:
+Restrict SurrealDB (port 8000) to the local VPC only. App Platform reaches the database through Caddy (see "Part 1b"), so port 8000 stays private.
 
 ```bash
-# Allow SSH access
-sudo ufw allow ssh
+# Allow SSH from your trusted source IPs only (not Anywhere)
+sudo ufw allow from YOUR_ADMIN_IP to any port 22
 
-# Allow database access ONLY from your app's VPC
-sudo ufw allow from <YOUR_APP_VPC_RANGE> to any port 8000
+# Allow SurrealDB on port 8000 from the droplet's VPC CIDR only
+# Get the VPC CIDR: doctl vpcs get <vpc-uuid>
+sudo ufw allow from 10.X.X.0/20 to any port 8000
+
+# Allow Caddy's ACME HTTP-01 challenge and HTTPS listener (configured in Part 1b)
+sudo ufw allow 80/tcp comment 'Caddy ACME'
+sudo ufw allow 8443/tcp comment 'Caddy HTTPS for SurrealDB proxy'
 
 # Enable the firewall
 sudo ufw enable
 ```
 
 The database setup is now complete.
+
+## Part 1b: TLS Reverse Proxy (Caddy)
+
+DigitalOcean App Platform containers block outbound connections on port 22, and App Platform instances don't join custom VPCs. The blog reaches SurrealDB through a Caddy reverse proxy terminating TLS on the droplet.
+
+### 1. Add DNS record
+
+Point a subdomain (e.g. `db.alexthola.com`) at the droplet's public IP:
+
+```bash
+doctl compute domain records create alexthola.com \
+  --record-type A --record-name db \
+  --record-data YOUR_DROPLET_PUBLIC_IP --record-ttl 300
+```
+
+### 2. Install Caddy
+
+```bash
+apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  > /etc/apt/sources.list.d/caddy-stable.list
+apt-get update && apt-get install -y caddy
+```
+
+### 3. Write `/etc/caddy/Caddyfile`
+
+```caddy
+{
+  email YOUR_EMAIL_FOR_ACME
+}
+
+db.YOUR_DOMAIN:8443 {
+  reverse_proxy http://127.0.0.1:8000
+}
+```
+
+### 4. Start and verify
+
+```bash
+systemctl enable --now caddy
+# From outside:
+curl https://db.YOUR_DOMAIN:8443/health   # expect HTTP 200
+```
+
+Let's Encrypt issues the certificate via HTTP-01 on port 80 (opened in step 2 of Part 1). Caddy renews automatically.
 
 ### Manual Database Setup (Alternative)
 
@@ -165,8 +213,8 @@ Once the database is running, deploy the application on the DigitalOcean App Pla
 ### 2. Configure the App
 
 -   **Name**: A descriptive name, e.g., `blog-web`.
--   **Region**: New York (NYC3) or the same region as your database Droplet.
--   **Instance Size**: Professional XS (~$12/month). The Professional tier is required for VPC networking to reach the SurrealDB droplet via private IP.
+-   **Region**: Match the database droplet's region.
+-   **Instance Size**: Basic is sufficient. No Professional-tier upgrade is needed since the app reaches SurrealDB over public HTTPS (via Caddy), not VPC private networking.
 -   **HTTP Port**: Set to `8080`.
 
 ### 3. Set Environment Variables
@@ -178,7 +226,7 @@ RUST_LOG=info
 LEPTOS_SITE_ADDR=0.0.0.0:8080
 LEPTOS_SITE_ROOT=site
 LEPTOS_HASH_FILES=true
-SURREAL_ADDRESS=http://YOUR_DROPLET_PRIVATE_IP:8000
+SURREAL_ADDRESS=https://db.YOUR_DOMAIN:8443
 SURREAL_NS=production
 SURREAL_DB=alexthola_blog
 SURREAL_ROOT_USER=root
@@ -186,9 +234,9 @@ SURREAL_ROOT_PASS=YOUR_SECURE_PASSWORD
 ```
 
 **Notes**:
-- Use the Droplet's **private IP** for `SURREAL_ADDRESS` to ensure traffic stays within the VPC.
-- Mark `SURREAL_ROOT_PASS` as encrypted.
-- Use `SURREAL_ROOT_USER`/`SURREAL_ROOT_PASS` for root-level authentication (recommended for simple setups). See `.env.example` for alternative authentication options.
+- `SURREAL_ADDRESS` points at the Caddy reverse proxy set up in Part 1b. TLS is terminated on the droplet; SurrealDB auth (`SURREAL_ROOT_USER`/`SURREAL_ROOT_PASS`) gates access.
+- Mark `SURREAL_ROOT_PASS`, `SURREAL_NS`, `SURREAL_DB`, and `SURREAL_ROOT_USER` as encrypted (`type: SECRET`) in the App spec.
+- Prior versions of this guide used an SSH tunnel or a private-IP direct connection; both have been retired. The tunnel scripts (`scripts/tunnel.sh`) remain in the repo as a no-op fallback when `TUNNEL_HOST` is unset.
 
 ### 4. Deploy
 
@@ -208,17 +256,17 @@ The final step is to apply the database schema.
 
 ```bash
 # Set environment variables locally
-export SURREAL_ADDRESS="http://YOUR_DROPLET_PUBLIC_IP:8000"
+export SURREAL_ADDRESS="https://db.YOUR_DOMAIN:8443"
 export SURREAL_NS="production"
 export SURREAL_DB="alexthola_blog"
 export SURREAL_ROOT_USER="root"
 export SURREAL_ROOT_PASS="YOUR_SECURE_PASSWORD"
 
-# Connect to the database and import the schema
+# Connect through the Caddy proxy and import the schema
 surreal sql --conn $SURREAL_ADDRESS --user $SURREAL_ROOT_USER --pass $SURREAL_ROOT_PASS --ns $SURREAL_NS --db $SURREAL_DB < migrations/schema.surql
 ```
 
-**Note**: For this one-time setup, you can temporarily open the firewall to your local IP or run this command from a trusted server. Remember to close the firewall rule afterward.
+**Note**: Port 8000 on the droplet is VPC-only, so direct `http://PUBLIC_IP:8000` connections are blocked by UFW. Route all admin traffic through the public Caddy endpoint (`db.YOUR_DOMAIN:8443`) or SSH into the droplet and run `surreal sql` locally against `http://localhost:8000`.
 
 ## Troubleshooting Guide
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -102,19 +102,24 @@ ps aux | grep surreal | grep -v grep
 
 **2. Configure the Firewall**
 
-Restrict SurrealDB (port 8000) to the local VPC only. App Platform reaches the database through Caddy (see "Part 1b"), so port 8000 stays private.
+Caddy (set up in Part 1b) runs on the same droplet and reaches SurrealDB at `127.0.0.1:8000`, so port 8000 stays bound to loopback and is never exposed on any external interface. Public ingress is limited to SSH for admins and Caddy's ACME + HTTPS listener.
+
+> **Lockout safeguard**: before running `ufw enable`, open a second SSH session in a separate terminal and confirm it stays connected. If you typo `YOUR_ADMIN_IP`, the existing session keeps you in until you fix the rule; without that, recovery requires the DigitalOcean web console.
 
 ```bash
 # Allow SSH from your trusted source IPs only (not Anywhere)
 sudo ufw allow from YOUR_ADMIN_IP to any port 22
 
-# Allow SurrealDB on port 8000 from the droplet's VPC CIDR only
-# Get the VPC CIDR: doctl vpcs get <vpc-uuid>
-sudo ufw allow from 10.X.X.0/20 to any port 8000
-
 # Allow Caddy's ACME HTTP-01 challenge and HTTPS listener (configured in Part 1b)
 sudo ufw allow 80/tcp comment 'Caddy ACME'
 sudo ufw allow 8443/tcp comment 'Caddy HTTPS for SurrealDB proxy'
+
+# SurrealDB on port 8000 stays loopback-only (no UFW rule needed; the
+# systemd unit binds to 0.0.0.0 but UFW's default-deny policy keeps it
+# reachable only via 127.0.0.1, which is what Caddy uses).
+# To be explicit and survive future bind changes, you can additionally
+# pin SurrealDB to localhost in the unit:
+#   ExecStart=... --bind 127.0.0.1:8000 ...
 
 # Enable the firewall
 sudo ufw enable
@@ -122,56 +127,9 @@ sudo ufw enable
 
 The database setup is now complete.
 
-## Part 1b: TLS Reverse Proxy (Caddy)
+## Part 1 (Alternative): Manual Database Setup
 
-DigitalOcean App Platform containers block outbound connections on port 22, and App Platform instances don't join custom VPCs. The blog reaches SurrealDB through a Caddy reverse proxy terminating TLS on the droplet.
-
-### 1. Add DNS record
-
-Point a subdomain (e.g. `db.alexthola.com`) at the droplet's public IP:
-
-```bash
-doctl compute domain records create alexthola.com \
-  --record-type A --record-name db \
-  --record-data YOUR_DROPLET_PUBLIC_IP --record-ttl 300
-```
-
-### 2. Install Caddy
-
-```bash
-apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
-  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
-curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
-  > /etc/apt/sources.list.d/caddy-stable.list
-apt-get update && apt-get install -y caddy
-```
-
-### 3. Write `/etc/caddy/Caddyfile`
-
-```caddy
-{
-  email YOUR_EMAIL_FOR_ACME
-}
-
-db.YOUR_DOMAIN:8443 {
-  reverse_proxy http://127.0.0.1:8000
-}
-```
-
-### 4. Start and verify
-
-```bash
-systemctl enable --now caddy
-# From outside:
-curl https://db.YOUR_DOMAIN:8443/health   # expect HTTP 200
-```
-
-Let's Encrypt issues the certificate via HTTP-01 on port 80 (opened in step 2 of Part 1). Caddy renews automatically.
-
-### Manual Database Setup (Alternative)
-
-If you prefer manual Droplet configuration, create a Droplet with the listed specifications (without user data) and follow these steps.
+If you prefer manual Droplet configuration over the cloud-init script, create a Droplet with the specifications above (without user data) and run these steps. The manual path replaces only the **service install + systemd unit**; you still need Part 1, Post-Provisioning Steps 1-2 (password + firewall) and all of Part 1b (Caddy + TLS) before any client can reach the database.
 
 **1. Install SurrealDB**
 
@@ -191,12 +149,69 @@ chmod 700 /var/lib/surrealdb
 
 **3. Configure and Start the Service**
 
-Create the systemd service file `/etc/systemd/system/surrealdb.service` with the same content as in the `cloud-init` script, then create the `/etc/surrealdb/env` credentials file as described in the Post-Provisioning section above.
+Create the systemd service file `/etc/systemd/system/surrealdb.service` with the same content as in the `cloud-init` script, then create the `/etc/surrealdb/env` credentials file as described in **Post-Provisioning Steps 1** above.
 
 ```bash
 sudo systemctl daemon-reload
 sudo systemctl enable --now surrealdb
 ```
+
+**4. Finish provisioning**
+
+Before continuing to Part 1b, run **Post-Provisioning Steps 1-2** (password + firewall) from the cloud-init flow above. Without them, SurrealDB stays reachable on `0.0.0.0:8000` with no auth password set and no firewall.
+
+## Part 1b: TLS Reverse Proxy (Caddy)
+
+DigitalOcean App Platform containers block outbound connections on port 22, and App Platform instances don't join custom VPCs. The blog reaches SurrealDB through a Caddy reverse proxy terminating TLS on the droplet.
+
+### 1. Add DNS record
+
+Point a subdomain (e.g. `db.alexthola.com`) at the droplet's public IP:
+
+```bash
+doctl compute domain records create alexthola.com \
+  --record-type A --record-name db \
+  --record-data YOUR_DROPLET_PUBLIC_IP --record-ttl 300
+```
+
+### 2. Install Caddy
+
+These commands require root. Run them as `root` (e.g. `sudo -i`) or prefix each with `sudo`:
+
+```bash
+sudo apt-get install -y debian-keyring debian-archive-keyring apt-transport-https
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | sudo tee /etc/apt/sources.list.d/caddy-stable.list > /dev/null
+sudo apt-get update && sudo apt-get install -y caddy
+```
+
+The HTTP-01 ACME challenge requires port 80 reachable from the public internet — that's the rule added in **Part 1, Post-Provisioning Step 2**. Without it, Caddy will fail to issue the certificate on first start.
+
+### 3. Write `/etc/caddy/Caddyfile`
+
+```caddy
+{
+  email YOUR_EMAIL_FOR_ACME
+}
+
+db.YOUR_DOMAIN:8443 {
+  reverse_proxy http://127.0.0.1:8000
+}
+```
+
+### 4. Start and verify
+
+```bash
+sudo systemctl enable --now caddy
+
+# Confirm cert issuance and reverse proxy reachability
+sudo journalctl -u caddy -n 50 | grep -i 'certificate obtained'
+curl -v https://db.YOUR_DOMAIN:8443/health   # expect HTTP/2 200
+```
+
+Let's Encrypt issues the certificate via HTTP-01 on port 80 (opened in step 2 of Part 1). Renewal happens automatically; if port 80 is ever blocked or DNS changes, the cert will silently expire after ~30 days, so revisit this verification step whenever droplet networking changes.
 
 ## Part 2: Application Deployment
 
@@ -236,7 +251,9 @@ SURREAL_ROOT_PASS=YOUR_SECURE_PASSWORD
 **Notes**:
 - `SURREAL_ADDRESS` points at the Caddy reverse proxy set up in Part 1b. TLS is terminated on the droplet; SurrealDB auth (`SURREAL_ROOT_USER`/`SURREAL_ROOT_PASS`) gates access.
 - Mark `SURREAL_ROOT_PASS`, `SURREAL_NS`, `SURREAL_DB`, and `SURREAL_ROOT_USER` as encrypted (`type: SECRET`) in the App spec.
-- Prior versions of this guide used an SSH tunnel or a private-IP direct connection; both have been retired. The tunnel scripts (`scripts/tunnel.sh`) remain in the repo as a no-op fallback when `TUNNEL_HOST` is unset.
+- Prior versions of this guide used an SSH tunnel or a private-IP direct connection; both have been retired. The tunnel scripts (`scripts/tunnel.sh`) remain in the repo and are still wired into the Dockerfile entrypoint, but only as a no-op shim:
+  - **Leave `TUNNEL_HOST` unset** in App Platform. With `TUNNEL_HOST` empty, `tunnel.sh` logs `No TUNNEL_HOST set, starting app without tunnel` and `exec`s `/app/blog` directly.
+  - Verify on first deploy: `doctl apps logs <APP_ID> --type=run | grep 'No TUNNEL_HOST set'`. If you see autossh log lines instead, the env var is being inherited from somewhere — clear it before re-deploying, since with `TUNNEL_HOST` set but tunnel keys missing or autossh failing, `tunnel.sh` currently falls through to `exec /app/blog` anyway and the deploy will look healthy while routing is wrong.
 
 ### 4. Deploy
 
@@ -262,11 +279,21 @@ export SURREAL_DB="alexthola_blog"
 export SURREAL_ROOT_USER="root"
 export SURREAL_ROOT_PASS="YOUR_SECURE_PASSWORD"
 
-# Connect through the Caddy proxy and import the schema
-surreal sql --conn $SURREAL_ADDRESS --user $SURREAL_ROOT_USER --pass $SURREAL_ROOT_PASS --ns $SURREAL_NS --db $SURREAL_DB < migrations/schema.surql
+# Apply migrations through the Caddy proxy in numeric order.
+# `surreal sql` does not abort on per-statement errors, so loop file-by-file
+# and stop on the first non-zero exit so a partial schema can't go unnoticed.
+set -e
+for migration in migrations/00*.surql; do
+  echo "Applying ${migration}..."
+  surreal sql \
+    --conn "$SURREAL_ADDRESS" \
+    --user "$SURREAL_ROOT_USER" --pass "$SURREAL_ROOT_PASS" \
+    --ns "$SURREAL_NS" --db "$SURREAL_DB" \
+    < "$migration"
+done
 ```
 
-**Note**: Port 8000 on the droplet is VPC-only, so direct `http://PUBLIC_IP:8000` connections are blocked by UFW. Route all admin traffic through the public Caddy endpoint (`db.YOUR_DOMAIN:8443`) or SSH into the droplet and run `surreal sql` locally against `http://localhost:8000`.
+**Note**: SurrealDB on port 8000 is bound to `127.0.0.1` and not opened in UFW, so direct `http://PUBLIC_IP:8000` connections are unreachable from off-droplet. Run all admin traffic through the public Caddy endpoint (`db.YOUR_DOMAIN:8443`) or SSH into the droplet and run `surreal sql` locally against `http://localhost:8000`.
 
 ## Troubleshooting Guide
 
@@ -342,7 +369,7 @@ If the issue persists after several hours, double-check the DNS records in your 
 
 ### Security
 
--   **Database**: Access restricted by firewall to app's private VPC. Use strong, generated password, rotated quarterly.
+-   **Database**: SurrealDB binds to `127.0.0.1:8000` on the droplet and is reachable only via the Caddy reverse proxy on `:8443`, gated by `SURREAL_ROOT_USER`/`SURREAL_ROOT_PASS`. Use a strong generated password, rotated quarterly.
 -   **Application**: App Platform provides automatic HTTPS, DDoS mitigation, and a managed runtime.
 -   **Secrets**: Credentials not stored in repository; managed as encrypted environment variables in App Platform.
 

--- a/README.md
+++ b/README.md
@@ -1,148 +1,229 @@
 # Blog Engine
 
 [![Build](https://github.com/athola/blog/actions/workflows/rust.yml/badge.svg)](https://github.com/athola/blog/actions/workflows/rust.yml)
+[![Secrets Scan](https://github.com/athola/blog/actions/workflows/secrets-scan.yml/badge.svg)](https://github.com/athola/blog/actions/workflows/secrets-scan.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
+[![Rust edition](https://img.shields.io/badge/edition-2021-orange.svg)](Cargo.toml)
 
-**A full-stack Rust blog engine built with Leptos and Axum.** This project
-powers [alexthola.com](https://alexthola.com) with server-side rendering,
-real-time data via SurrealDB, and automated security scanning.
+**A full-stack Rust blog engine built with Leptos and Axum.** This
+project powers [alexthola.com](https://alexthola.com) with server-side
+rendering, real-time data via SurrealDB, and automated security scanning
+on every commit.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [Features](#features)
+- [Architecture](#architecture)
+- [Development](#development)
+- [Deployment](#deployment)
+- [Documentation](#documentation)
+- [Tech Stack](#tech-stack)
+- [Security](#security)
+- [Performance](#performance)
+- [Roadmap](#roadmap)
+- [Contributing](#contributing)
+- [License](#license)
 
 ## Quick Start
 
-Get your development environment running in 2 minutes:
+Get a local development environment running in a couple of minutes:
 
 ```bash
-# Clone and setup
 git clone https://github.com/athola/blog.git
 cd blog
-make install-pkgs
-
-# Start development server
-make watch
+make install-pkgs        # installs cargo-leptos, cargo-make, cargo-audit
+make install-surrealdb   # downloads SurrealDB into ~/.surrealdb
+make watch               # starts SurrealDB, backend, and live-reload frontend
 ```
 
-Visit `http://127.0.0.1:3007` to see your blog running locally.
+Visit `http://127.0.0.1:3007` to see the blog running locally. Run
+`make help` to list every available target.
 
 ## Features
 
-- **Fast Performance** - Server-side rendering achieves ~200ms initial load times
-- **Automated Security** - Every commit scanned by Gitleaks, Semgrep, and TruffleHog
-- **Markdown Support** - KaTeX integration for mathematical content rendering
-- **Real-time Updates** - Live data synchronization via SurrealDB
-- **Responsive Design** - Mobile-first approach with TailwindCSS
-- **WASM Frontend** - WebAssembly compilation, ~150KB gzipped
+- **Server-side rendering** via Leptos + Axum for fast first paint and
+  progressive hydration.
+- **Real-time data** backed by SurrealDB 2.x with automatic connection
+  retry and migrations under `migrations/`.
+- **Markdown with math**: KaTeX rendering for technical posts.
+- **Responsive styling** through TailwindCSS v4 (`@tailwindcss/cli`)
+  with a typography plugin for long-form content.
+- **WebAssembly frontend** compiled by `cargo-leptos`; the client bundle
+  ships as gzipped WASM.
+- **Automated security scanning**: Gitleaks, Semgrep, and TruffleHog
+  run on every commit via GitHub Actions.
+- **Reproducible deployments**: containerized via `Dockerfile` and
+  shipped to DigitalOcean App Platform with Caddy fronting SurrealDB
+  (see [Deployment](#deployment)).
 
-## Architecture Overview
+## Architecture
 
 ```mermaid
 graph LR
-    A[Frontend<br/>Leptos<br/>WASM ~150KB] --> B[Backend<br/>Axum<br/>SSR + API]
-    B --> C[Database<br/>SurrealDB<br/>Real-time]
+    U[Browser] --> APP[Axum app<br/>SSR + API<br/>DO App Platform]
+    APP --> WASM[Leptos WASM<br/>hydrated client]
+    APP -->|TLS :8443| CADDY[Caddy reverse proxy<br/>droplet]
+    CADDY -->|localhost :8000| DB[SurrealDB 2.x<br/>droplet]
 
-    style A fill:#e3f2fd,stroke:#1e40af
-    style B fill:#10b981,stroke:#047857
-    style C fill:#f59e0b,stroke:#d97706
+    style APP fill:#10b981,stroke:#047857,color:#0b1f17
+    style WASM fill:#e3f2fd,stroke:#1e40af,color:#0b1f42
+    style CADDY fill:#a78bfa,stroke:#5b21b6,color:#1e1b4b
+    style DB fill:#f59e0b,stroke:#b45309,color:#3b1d03
 ```
 
-### Core Components
+### Core components
 
-- **Frontend** - Leptos compiled to WASM (~150KB gzipped) with TailwindCSS
-- **Backend** - Axum web server handling both SSR and API requests
-- **Database** - SurrealDB 2.x with automatic connection retry
-- **Build System** - cargo-leptos for development, cargo-make for automation
-
-## Documentation
-
-- **[Architecture Guide](wiki/Architecture.md)** - Detailed system architecture
-- **[API Reference](wiki/API-Reference.md)** - Endpoint and data model reference
-- **[Development Workflow](wiki/Development-Workflow.md)** - Local setup and testing
-- **[Deployment Guide](DEPLOYMENT.md)** - Production deployment instructions
-- **[Security Policy](SECURITY.md)** - Security reporting and policies
+- **`frontend/`**: Leptos client compiled to WASM.
+- **`app/`**: shared component library and routing.
+- **`server/`**: Axum application handling SSR, API routes, and
+  database access.
+- **`markdown/`**: Markdown pipeline with KaTeX math support.
+- **`shared_utils/`**: cross-crate helpers and types.
+- **Build system**: `cargo-leptos` for dev/hot-reload and
+  `cargo-make` (`Makefile.toml`) for CI and release orchestration.
 
 ## Development
 
 ### Prerequisites
 
-- Rust nightly with WASM target: `rustup target add wasm32-unknown-unknown`
-- SurrealDB 2.6+
+- **Rust** toolchain with the WASM target:
+  `rustup target add wasm32-unknown-unknown`.
+- **`cargo-leptos`**, **`cargo-make`**, **`cargo-audit`**: installed
+  automatically by `make install-pkgs`.
+- **SurrealDB 2.6+**: installed via `make install-surrealdb` or from
+  [surrealdb.com](https://surrealdb.com/).
+- **Node.js**: required only for the TailwindCSS v4 CLI used during
+  asset builds; `npm install --silent` pulls `@tailwindcss/cli` and
+  `katex` from [`package.json`](package.json).
 
-### Available Commands
+### Available commands
 
 ```bash
-# Quick Start
-make dev             # Start development server with live reload (alias: watch)
-make all             # Build and run tests
+# Daily development
+make dev             # live-reload frontend + backend (alias: watch)
+make all             # build workspace and run tests
 
 # Build
-make build           # Build workspace artifacts (debug)
-make build-release   # Build for production
-make check           # Fast type-check without codegen
-make clean           # Remove build artifacts
+make build           # debug build
+make build-release   # production build
+make check           # fast type-check without codegen
+make clean           # remove build artifacts
 
-# Quality
-make fmt             # Format code
-make lint            # Run clippy with warnings as errors
-make validate        # Run full validation (format + lint + test + security)
+# Quality gates
+make fmt             # format code
+make lint            # clippy with warnings as errors
+make validate        # fmt + lint + test + security scan
+make test            # run full test suite
+make test-ci         # lightweight CI subset
+make test-coverage   # cargo-llvm-cov HTML report
 
-# Testing
-make test            # Run full test suite
-make test-ci         # Lightweight CI tests
-make test-coverage   # Generate coverage report
-
-# CI Pipeline
-make ci              # Full CI: format check, lint, test, build release
+# CI pipeline
+make ci              # fmt check + lint + test + release build
 
 # Docker (production image)
-docker build -t blog .                    # Build locally
-docker run -p 8080:8080 blog /app/blog    # Run locally
+docker build -t blog .
+docker run -p 8080:8080 blog /app/blog
 ```
 
-Run `make help` for a complete list of available targets.
+Run `make help` for the full list of targets.
+
+## Deployment
+
+Production is deployed to DigitalOcean App Platform with SurrealDB
+hosted on a dedicated Droplet. Because App Platform containers cannot
+join custom VPCs or reach the SurrealDB port directly, a **Caddy
+reverse proxy** on the database droplet terminates TLS on `:8443` and
+forwards to SurrealDB at `localhost:8000`. Firewall rules (UFW)
+restrict the SurrealDB port to the loopback interface only.
+
+Estimated monthly cost: ~$26 ($12 app, $12 Droplet, $2.40 backups).
+
+See the [Deployment Guide](DEPLOYMENT.md) for the full walkthrough:
+cloud-init provisioning, Caddy configuration, App Platform spec,
+operational runbooks, and troubleshooting.
+
+## Documentation
+
+- [Architecture](wiki/Architecture.md): component breakdown and data
+  flow.
+- [API Reference](wiki/API-Reference.md): HTTP endpoints and data
+  models.
+- [Development Workflow](wiki/Development-Workflow.md): local setup,
+  testing, and common `make` targets.
+- [Deployment Guide](DEPLOYMENT.md): DigitalOcean + Caddy production
+  setup.
+- [Security Guide](wiki/Security-Guide.md): hardening practices and
+  scanning pipeline.
+- [Security Policy](SECURITY.md): vulnerability reporting.
+- [Roadmap](PLAN.md): planned features and ordering rationale.
 
 ## Tech Stack
 
-- **Framework**: [Leptos](https://leptos.dev/) - Full-stack Rust web framework
-- **Database**: [SurrealDB](https://surrealdb.com/) - Modern real-time database
-- **Web Server**: [Axum](https://github.com/tokio-rs/axum) - Async web framework
-- **CSS**: [TailwindCSS](https://tailwindcss.com/) - Utility-first CSS framework
+- **[Leptos](https://leptos.dev/)**: full-stack Rust framework with
+  fine-grained reactivity.
+- **[Axum](https://github.com/tokio-rs/axum)**: async web framework
+  built on Tokio and Tower.
+- **[SurrealDB](https://surrealdb.com/)**: multi-model real-time
+  database.
+- **[TailwindCSS](https://tailwindcss.com/)**: utility-first styling.
+- **[KaTeX](https://katex.org/)**: fast math typesetting for posts.
 
 ## Security
 
-This project implements defense-in-depth security:
+Defense-in-depth is applied at commit, CI, and deployment layers:
 
-- **Automated Scanning** - Every commit scanned by Gitleaks, Semgrep and TruffleHog
-- **CI Security Gates** - Security failures block deployment
-- **Dependency Audits** - Weekly `cargo audit` for CVE detection
-- **Secure Defaults** - Secure-by-default configuration
+- **Secret scanning**: Gitleaks, Semgrep, and TruffleHog run on every
+  push (see `.github/workflows/secrets-scan.yml`).
+- **CI gates**: security failures block deployment.
+- **Dependency audits**: weekly `cargo audit` in
+  `.github/workflows/ci-cd.yml`.
+- **Hardened defaults**: UFW restricts SurrealDB to localhost; Caddy
+  handles TLS; secrets live in App Platform env vars, never in the
+  repo.
 
-Run security scan manually:
+Run the local secret scan with:
 
 ```bash
 ./scripts/run_secret_scan.sh
 ```
 
+To report a vulnerability, follow the disclosure process in
+[SECURITY.md](SECURITY.md). **Do not open a public GitHub issue for
+security reports.**
+
 ## Performance
 
-- **First Contentful Paint**: ~200ms
-- **WASM Bundle Size**: ~150KB gzipped
-- **Database Query Time**: <50ms for typical operations
-- **Memory Usage**: <50MB in production
+Measured targets for production (`alexthola.com`):
+
+- **First Contentful Paint**: ~200 ms
+- **WASM bundle size**: ~150 KB gzipped
+- **Database query latency**: <50 ms for typical operations
+- **Memory footprint**: <50 MB resident
+
+These are operational targets rather than guaranteed SLAs; regressions
+are flagged by CI integration tests before deploy.
 
 ## Roadmap
 
-Planned features are tracked in [PLAN.md](PLAN.md). Highlights:
+Planned features and rationale live in [PLAN.md](PLAN.md). Highlights:
 
-- **Q1 2026** - Dark/light theme toggle, syntax highlighting, post search, related articles
-- **Q2 2026** - Comments, social sharing, newsletter signup
-- **Backlog** - Admin interface, offline reading (PWA), AI-powered suggestions
+- **Q1 2026**: dark/light theme toggle, server-side syntax
+  highlighting (likely `syntect`), full-text post search via SurrealDB,
+  and related-article suggestions.
+- **Q2 2026**: self-hosted comments, lightweight social sharing, and
+  a privacy-first newsletter signup.
+- **Backlog**: admin interface, PWA offline reading, and experimental
+  local AI-assisted tagging.
 
 ## Contributing
 
-Contributions are welcome. Please open an issue to discuss proposed changes
-before submitting a pull request. Run `make validate` to verify formatting,
-linting, tests, and security scans pass before pushing.
+Contributions are welcome. Please open an issue to discuss proposed
+changes before submitting a pull request. Run `make validate` to
+verify that formatting, linting, tests, and security scans pass before
+pushing.
 
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0.
-See the [LICENSE](LICENSE) file for details.
+Licensed under the GNU Affero General Public License v3.0. See
+[LICENSE](LICENSE) for the full text.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Build](https://github.com/athola/blog/actions/workflows/rust.yml/badge.svg)](https://github.com/athola/blog/actions/workflows/rust.yml)
 [![Secrets Scan](https://github.com/athola/blog/actions/workflows/secrets-scan.yml/badge.svg)](https://github.com/athola/blog/actions/workflows/secrets-scan.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![Rust edition](https://img.shields.io/badge/edition-2021-orange.svg)](Cargo.toml)
 
 **A full-stack Rust blog engine built with Leptos and Axum.** This
 project powers [alexthola.com](https://alexthola.com) with server-side
@@ -174,13 +173,16 @@ operational runbooks, and troubleshooting.
 Defense-in-depth is applied at commit, CI, and deployment layers:
 
 - **Secret scanning**: Gitleaks, Semgrep, and TruffleHog run on every
-  push (see `.github/workflows/secrets-scan.yml`).
-- **CI gates**: security failures block deployment.
-- **Dependency audits**: weekly `cargo audit` in
-  `.github/workflows/ci-cd.yml`.
-- **Hardened defaults**: UFW restricts SurrealDB to localhost; Caddy
-  handles TLS; secrets live in App Platform env vars, never in the
-  repo.
+  push and weekly via cron (see
+  `.github/workflows/secrets-scan.yml`); a positive scan fails the
+  job and blocks deployment.
+- **Dependency audits**: `cargo audit` runs on every push and PR in
+  `.github/workflows/rust.yml` (gated on `Cargo.lock` changes); the
+  weekly cron job lives in `secrets-scan.yml`.
+- **Hardened defaults**: UFW pins SurrealDB to localhost on the
+  database droplet; Caddy terminates TLS on `:8443` and forwards to
+  `127.0.0.1:8000`; secrets live in App Platform env vars, never in
+  the repo.
 
 Run the local secret scan with:
 
@@ -197,7 +199,9 @@ security reports.**
 Measured targets for production (`alexthola.com`):
 
 - **First Contentful Paint**: ~200 ms
-- **WASM bundle size**: ~150 KB gzipped
+- **WASM bundle size**: ~1.6 MB gzipped (8.3 MB raw); `wasm-opt` is
+  currently disabled in `frontend/Cargo.toml`, so the artifact is the
+  unminified `wasm-release` profile output.
 - **Database query latency**: <50 ms for typical operations
 - **Memory footprint**: <50 MB resident
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Blog API
-  version: 0.1.7
+  version: 0.1.8
 servers:
   - url: https://<your-domain>
 paths:


### PR DESCRIPTION
## Summary

Three changes bundled on a docs branch:

1. **DEPLOYMENT.md** — align with the live architecture after the SSH-tunnel → Caddy migration (#62).
2. **README.md** — refresh structure and prose; add deployment section + table of contents.
3. **`chore(release)`** — bump workspace 0.1.7 → 0.1.8 (`Cargo.toml`, `Cargo.lock`, `openapi.yaml`).

## DEPLOYMENT.md changes

- **Firewall (Part 1, Step 2)**: SSH restricted to trusted admin IPs (not Anywhere); add UFW rules for Caddy ACME (80) and HTTPS listener (8443); keep SurrealDB (8000) VPC-only.
- **New Part 1b**: TLS reverse proxy setup — DNS record via doctl, Caddy install from official repo, Caddyfile with `reverse_proxy`, start + verify steps.
- **Part 2, App config**: drop the misleading Professional-tier / VPC-networking claim.
- **Part 2, Env vars**: change `SURREAL_ADDRESS` example from `http://YOUR_DROPLET_PRIVATE_IP:8000` to `https://db.YOUR_DOMAIN:8443`; note the `tunnel.sh` no-op fallback.
- **Part 2, Schema import**: route through the Caddy endpoint or SSH+localhost since port 8000 is no longer publicly reachable.

## README.md changes

- Add Table of Contents and dedicated Deployment section.
- Restructure Quick Start, Features, Architecture, Documentation, Tech Stack, Security, Performance, Roadmap, Contributing.
- Update the architecture diagram to reflect the Caddy reverse proxy hop.
- Replace marketing-style bullets with concrete, operator-oriented prose.
- Add `secrets-scan` workflow badge.

## Version bump

Workspace 0.1.7 → 0.1.8. All 6 workspace crates and `openapi.yaml` `info.version` synced. Release narrative for 0.1.8 lives in #62 (`deploy-hotfix-0.1.8`).

## Why

The previous text described paths that either never worked (App Platform isn't in a custom VPC) or reflected a now-retired architecture (SSH tunnel over port 443).

## Test plan

- [x] `wc -l DEPLOYMENT.md` → 405 (<500 strict limit)
- [x] Zero filler phrases (no "leverage", "comprehensive", etc.) in either doc
- [x] Em-dash density 0.52/1000 words across changed docs
- [x] All commands in updated sections reference real current state
- [x] Workspace version sync verified across `Cargo.toml`, `Cargo.lock`, `openapi.yaml`

See the test-plan comment for operator-facing verification steps (Caddy validate, end-to-end curl, UFW state check).
